### PR TITLE
feat: aws channel add prompt caching for faster model interface

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -31,6 +31,7 @@
     <jooq.version>3.14.15</jooq.version>
     <redisson.version>3.9.1</redisson.version>
     <apollo.version>2.1.0</apollo.version>
+    <awssdk.version>2.31.42</awssdk.version>
   </properties>
 
   <licenses>

--- a/api/sdk/src/main/java/com/ke/bella/openapi/protocol/completion/CompletionResponse.java
+++ b/api/sdk/src/main/java/com/ke/bella/openapi/protocol/completion/CompletionResponse.java
@@ -154,6 +154,8 @@ public class CompletionResponse extends OpenapiResponse {
         private int completion_tokens;
         private int prompt_tokens;
         private int total_tokens;
+		private int cache_write_input_tokens;
+		private int cache_read_input_tokens;
 
         public TokenUsage add(TokenUsage u) {
             this.completion_tokens += u.completion_tokens;

--- a/api/sdk/src/main/java/com/ke/bella/openapi/protocol/completion/CompletionResponse.java
+++ b/api/sdk/src/main/java/com/ke/bella/openapi/protocol/completion/CompletionResponse.java
@@ -154,8 +154,6 @@ public class CompletionResponse extends OpenapiResponse {
         private int completion_tokens;
         private int prompt_tokens;
         private int total_tokens;
-		private int cache_write_input_tokens;
-		private int cache_read_input_tokens;
 
         public TokenUsage add(TokenUsage u) {
             this.completion_tokens += u.completion_tokens;

--- a/api/server/pom.xml
+++ b/api/server/pom.xml
@@ -217,7 +217,17 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>bedrockruntime</artifactId>
-            <version>2.31.42</version>
+            <version>${awssdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>apache-client</artifactId>
+            <version>${awssdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>netty-nio-client</artifactId>
+            <version>${awssdk.version}</version>
         </dependency>
         <dependency>
             <groupId>com.github.ben-manes.caffeine</groupId>

--- a/api/server/pom.xml
+++ b/api/server/pom.xml
@@ -217,7 +217,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>bedrockruntime</artifactId>
-            <version>2.30.29</version>
+            <version>2.31.42</version>
         </dependency>
         <dependency>
             <groupId>com.github.ben-manes.caffeine</groupId>

--- a/api/server/src/main/java/com/ke/bella/openapi/protocol/completion/AwsClientManager.java
+++ b/api/server/src/main/java/com/ke/bella/openapi/protocol/completion/AwsClientManager.java
@@ -3,11 +3,8 @@ package com.ke.bella.openapi.protocol.completion;
 import java.net.URI;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
-import java.time.temporal.Temporal;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.TimeUnit;
-
 import org.apache.commons.lang3.StringUtils;
 
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
@@ -16,9 +13,14 @@ import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.core.SdkSystemSetting;
 import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
 import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.http.Protocol;
+import software.amazon.awssdk.http.SdkHttpConfigurationOption;
+import software.amazon.awssdk.http.apache.ApacheHttpClient;
+import software.amazon.awssdk.http.nio.netty.NettyNioAsyncHttpClient;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.bedrockruntime.BedrockRuntimeAsyncClient;
 import software.amazon.awssdk.services.bedrockruntime.BedrockRuntimeClient;
+import software.amazon.awssdk.utils.AttributeMap;
 import software.amazon.awssdk.utils.ToString;
 
 public class AwsClientManager {
@@ -35,7 +37,13 @@ public class AwsClientManager {
                         .endpointOverride(URI.create(endpoint))
                         .credentialsProvider(provide(accessKeyId, secretKey))
                         .region(Region.of(region))
-                        .overrideConfiguration(ClientOverrideConfiguration.builder().apiCallTimeout(Duration.of(180, ChronoUnit.SECONDS)).build())
+                        .httpClient(ApacheHttpClient.builder()
+                                .buildWithDefaults(AttributeMap.builder()
+                                        .put(SdkHttpConfigurationOption.PROTOCOL, Protocol.HTTP1_1)
+                                        .build()))
+                        .overrideConfiguration(ClientOverrideConfiguration.builder()
+                                .apiCallTimeout(Duration.of(180, ChronoUnit.SECONDS))
+                                .build())
                         .build());
     }
 
@@ -45,7 +53,13 @@ public class AwsClientManager {
                         .endpointOverride(URI.create(endpoint))
                         .credentialsProvider(provide(accessKeyId, secretKey))
                         .region(Region.of(region))
-                        .overrideConfiguration(ClientOverrideConfiguration.builder().apiCallTimeout(Duration.of(180, ChronoUnit.SECONDS)).build())
+                        .httpClient(NettyNioAsyncHttpClient.builder()
+                                .buildWithDefaults(AttributeMap.builder()
+                                        .put(SdkHttpConfigurationOption.PROTOCOL, Protocol.HTTP1_1)
+                                        .build()))
+                        .overrideConfiguration(ClientOverrideConfiguration.builder()
+                                .apiCallTimeout(Duration.of(180, ChronoUnit.SECONDS))
+                                .build())
                         .build());
     }
 


### PR DESCRIPTION
aws 通道支持 prompt caching：
- 协议 [ { "type": "image_url", "image_url": {"url":"data:image/png;base64,xxxx"}, "cache_control":{"type":"ephemeral"}}] 识别到“cache_control”，将调用 aws cachePoint api.
- 参考资料：https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html
