### PR TITLE
feat: messages-endpoint #70

### DIFF
--- a/api/CLAUDE.md
+++ b/api/CLAUDE.md
@@ -1,0 +1,80 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+Bella OpenAPI is a multi-module Maven project that provides an OpenAPI gateway for AI services. It acts as a unified interface supporting multiple AI providers (OpenAI, AWS Bedrock, Alibaba Cloud, Huoshan, etc.) through a pluggable adapter pattern.
+
+## Module Architecture
+- **sdk/**: Core SDK with protocol definitions, DTOs, and client interfaces
+- **spi/**: Service Provider Interface module with authentication and session management (CAS/OAuth)
+- **server/**: Main Spring Boot application with REST endpoints and business logic
+
+## Build & Development Commands
+
+### Basic Maven Commands
+```bash
+# Build all modules
+mvn clean compile
+
+# Run tests
+mvn test
+
+# Package without tests
+mvn package -DskipTests
+
+# Install to local repository
+mvn install
+```
+
+### Development Scripts
+```bash
+# Build the application
+./build.sh
+
+# Run the application
+./run.sh
+```
+
+## Key Architecture Patterns
+
+### Protocol Adapter Pattern
+The core architecture uses the **AdaptorManager** pattern to route requests to different AI providers:
+- `AdaptorManager` manages protocol adapters for each endpoint
+- `IProtocolAdaptor` interface defines how to communicate with each provider
+- Adapters are organized by endpoint type (completion, embedding, tts, asr, etc.)
+
+### Multi-Layer Architecture
+1. **Controllers** (`endpoints/`): REST API endpoints
+2. **Interceptors** (`intercept/`): Cross-cutting concerns (auth, quotas, metrics)
+3. **Protocol Layer** (`protocol/`): Provider-specific adapters
+4. **Repository Layer** (`db/repo/`): Database access with jOOQ
+
+### Database Integration
+- Uses jOOQ for database access with code generation
+- Generated POJOs and Records in `server/src/codegen/`
+- Database schema initialization scripts in `server/sql/`
+
+## Configuration
+- Main config: `server/src/main/resources/application.yml`
+- Multi-environment support with profile-specific configs
+- Uses Redis for caching (Redisson) and JetCache for L1/L2 caching
+- Apollo configuration center support (optional)
+
+## Testing
+- Test configuration: `application-ut.yml`
+- API test files in `server/src/test/resources/`
+- Mock implementations available for each protocol adapter
+
+## Key Directories
+- `server/src/main/java/com/ke/bella/openapi/endpoints/`: REST controllers
+- `server/src/main/java/com/ke/bella/openapi/protocol/`: Provider adapters
+- `server/src/main/java/com/ke/bella/openapi/intercept/`: Request/response interceptors
+- `sdk/src/main/java/com/ke/bella/openapi/protocol/`: Protocol DTOs and interfaces
+- `server/src/main/resources/lua/`: Lua scripts for Redis operations
+
+## Development Notes
+- When adding new AI providers, implement `IProtocolAdaptor` and register with `AdaptorManager`
+- Protocol-specific DTOs go in SDK module, implementation in server module
+- Cost calculation and metrics collection are handled through dedicated handlers
+- Some endpoints support both streaming and non-streaming responses

--- a/api/sdk/src/main/java/com/ke/bella/openapi/protocol/OpenapiResponse.java
+++ b/api/sdk/src/main/java/com/ke/bella/openapi/protocol/OpenapiResponse.java
@@ -1,5 +1,6 @@
 package com.ke.bella.openapi.protocol;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.ke.bella.openapi.common.exception.ChannelException;
 import lombok.AllArgsConstructor;
@@ -49,6 +50,7 @@ public class OpenapiResponse implements Serializable {
         /**
          * 安全检查结果为failed，返回error中包含检查结果
          */
+        @JsonInclude(JsonInclude.Include.NON_NULL)
         private Object sensitive;
         /**
          * code通常存在

--- a/api/sdk/src/main/java/com/ke/bella/openapi/protocol/completion/AwsProperty.java
+++ b/api/sdk/src/main/java/com/ke/bella/openapi/protocol/completion/AwsProperty.java
@@ -23,8 +23,6 @@ public class AwsProperty extends CompletionProperty {
     boolean supportThink;
     boolean supportCache;
     Map<String, Object> additionalParams = new HashMap<>();
-    Integer budgetTokens;
-    Integer defaultMaxTokens;
 
     @Override
     public Map<String, String> description() {
@@ -33,9 +31,8 @@ public class AwsProperty extends CompletionProperty {
         map.put("region", "部署区域");
         map.put("deployName", "部署名称");
         map.put("supportThink", "是否支持思考过程");
-        map.put("additionalParams", "请求需要的额外参数");
-        map.put("budgetTokens", "思考过程的最大token");
-        map.put("defaultMaxTokens", "max_tokens的最大值");
+        map.put("supportCache", "是否支持缓存");
+        map.put("additionalParams", "请求需要的额外参数");;
         return map;
     }
 }

--- a/api/sdk/src/main/java/com/ke/bella/openapi/protocol/completion/CompletionRequest.java
+++ b/api/sdk/src/main/java/com/ke/bella/openapi/protocol/completion/CompletionRequest.java
@@ -155,6 +155,12 @@ public class CompletionRequest implements UserRequest, Serializable {
      */
     private Boolean enable_thinking;
 
+    /**
+     * Constrains effort on reasoning for reasoning models. Currently supported values are low, medium, and high.
+     * Reducing reasoning effort can result in faster responses and fewer tokens used on reasoning in a response.
+     */
+    private Object reasoning_effort;
+
     @Data
     public static class StreamOptions {
         /**

--- a/api/sdk/src/main/java/com/ke/bella/openapi/protocol/completion/Message.java
+++ b/api/sdk/src/main/java/com/ke/bella/openapi/protocol/completion/Message.java
@@ -99,15 +99,29 @@ public class Message {
                     .function(FunctionCall.builder().name(name).arguments("").build())
                     .build();
         }
+
+        public static ToolCall fromFunctionIdAndName(String id, String name) {
+            return ToolCall.builder()
+                    .id(id)
+                    .type("function")
+                    .function(FunctionCall.builder().name(name).arguments("").build())
+                    .build();
+        }
     }
 
     @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
     public static class Tool {
         private String type;
         private Function function;
     }
 
     @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
     public static class Function {
 
         /**
@@ -138,10 +152,14 @@ public class Message {
          */
 
         @Data
+        @AllArgsConstructor
+        @NoArgsConstructor
+        @Builder
         public static class FunctionParameter {
             private String type;
             private List<String> required;
             private Object properties;
+            private boolean additionalProperties;
         }
     }
 

--- a/api/sdk/src/main/java/com/ke/bella/openapi/protocol/completion/OpenAIProperty.java
+++ b/api/sdk/src/main/java/com/ke/bella/openapi/protocol/completion/OpenAIProperty.java
@@ -19,7 +19,7 @@ public class OpenAIProperty extends CompletionProperty {
     AuthorizationProperty auth;
     String deployName;
     String apiVersion;
-    boolean supportStreamOptions;
+    boolean supportStreamOptions = true;
 
     @Override
     public Map<String, String> description() {

--- a/api/sdk/src/main/java/com/ke/bella/openapi/protocol/completion/StreamCompletionResponse.java
+++ b/api/sdk/src/main/java/com/ke/bella/openapi/protocol/completion/StreamCompletionResponse.java
@@ -28,6 +28,8 @@ public class StreamCompletionResponse extends OpenapiResponse {
      * 时间戳
      */
     private long created;
+
+    private String object = CHAT_COMPLETION_CHUNK_OBJECT;
     /**
      * 唯一id
      */

--- a/api/sdk/src/main/java/com/ke/bella/openapi/protocol/message/MessageRequest.java
+++ b/api/sdk/src/main/java/com/ke/bella/openapi/protocol/message/MessageRequest.java
@@ -1,0 +1,342 @@
+package com.ke.bella.openapi.protocol.message;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class MessageRequest {
+    private String model;
+    private List<InputMessage> messages;
+    @JsonProperty("max_tokens")
+    private Integer maxTokens;
+    private Metadata metadata;
+    @JsonProperty("stop_sequences")
+    private List<String> stopSequences;
+    private boolean stream;
+    @JsonDeserialize(using = SystemFieldDeserializer.class)
+    private Object system; // String or List<RequestTextBlock>
+    private Double temperature;
+    private ThinkingConfig thinking;
+    @JsonProperty("tool_choice")
+    private ToolChoice toolChoice;
+    private List<Tool> tools;
+    @JsonProperty("top_k")
+    private Integer topK;
+    @JsonProperty("top_p")
+    private Double topP;
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class InputMessage {
+        private String role; // "user" or "assistant"
+        @JsonDeserialize(using = ContentFieldDeserializer.class)
+        private Object content; // String or List<ContentBlock>
+    }
+
+    @JsonTypeInfo(
+            use = JsonTypeInfo.Id.NAME,
+            include = JsonTypeInfo.As.PROPERTY,
+            property = "type")
+    @JsonSubTypes({
+            @JsonSubTypes.Type(value = TextContentBlock.class, name = "text"),
+            @JsonSubTypes.Type(value = ImageContentBlock.class, name = "image"),
+            @JsonSubTypes.Type(value = ToolUseContentBlock.class, name = "tool_use"),
+            @JsonSubTypes.Type(value = ToolResultContentBlock.class, name = "tool_result")
+    })
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @Data
+    public static abstract class ContentBlock {
+        private String type;
+        private Object cache_control;
+    }
+
+    @Data
+    @NoArgsConstructor
+    @EqualsAndHashCode(callSuper = true)
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class TextContentBlock extends ContentBlock {
+        private String text;
+        public String getType() {
+            return "text";
+        }
+    }
+
+    @Data
+    @NoArgsConstructor
+    @EqualsAndHashCode(callSuper = true)
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class ImageContentBlock extends ContentBlock {
+        private ImageSource source;
+        public String getType() {
+            return "image";
+        }
+    }
+
+    @Data
+    @NoArgsConstructor
+    @EqualsAndHashCode(callSuper = true)
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class ToolUseContentBlock extends ContentBlock {
+        private String id;
+        private String name;
+        private Object input; // Consider defining a more specific type if schema is known
+
+        public String getType() {
+            return "tool_use";
+        }
+    }
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @EqualsAndHashCode(callSuper = true)
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class ToolResultContentBlock extends ContentBlock {
+        @JsonProperty("tool_use_id")
+        private String toolUseId;
+        private Object content; // String or List<ContentBlock> for complex results
+        @JsonProperty("is_error")
+        private Boolean isError;
+
+        public String getType() {
+            return "tool_result";
+        }
+    }
+
+
+    @JsonTypeInfo(
+        use = JsonTypeInfo.Id.NAME,
+        include = JsonTypeInfo.As.PROPERTY,
+        property = "type")
+    @JsonSubTypes({
+        @JsonSubTypes.Type(value = Base64ImageSource.class, name = "base64")
+    })
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @Data
+    public static abstract class ImageSource {
+        private String type;
+    }
+
+    @Data
+    @NoArgsConstructor
+    @EqualsAndHashCode(callSuper = true)
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class Base64ImageSource extends ImageSource {
+        @JsonProperty("media_type")
+        private String mediaType;
+        private String data;
+    }
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class Metadata {
+        @JsonProperty("user_id")
+        private String userId;
+    }
+
+    // For the 'system' field if it can be List<RequestTextBlock>
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class RequestTextBlock {
+        private String type; // "text"
+        private String text;
+        private Object cache_control;
+    }
+
+
+    @JsonTypeInfo(
+        use = JsonTypeInfo.Id.NAME,
+        include = JsonTypeInfo.As.PROPERTY,
+        property = "type",
+        defaultImpl = ThinkingConfigEnabled.class) // Default might be tricky; adjust as needed
+    @JsonSubTypes({
+        @JsonSubTypes.Type(value = ThinkingConfigEnabled.class, name = "enabled"),
+        @JsonSubTypes.Type(value = ThinkingConfigDisabled.class, name = "disabled")
+    })
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @Data
+    public static abstract class ThinkingConfig {
+         private String type;
+    }
+
+    @Data
+    @EqualsAndHashCode(callSuper = true)
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ThinkingConfigEnabled extends ThinkingConfig {
+        private Integer budget_tokens;
+        public String getType() {
+            return "enabled";
+        }
+    }
+
+    @Data
+    @EqualsAndHashCode(callSuper = true)
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class ThinkingConfigDisabled extends ThinkingConfig {
+        public String getType() {
+            return "disabled";
+        }
+    }
+
+
+    @JsonTypeInfo(
+            use = JsonTypeInfo.Id.NAME,
+            include = JsonTypeInfo.As.PROPERTY,
+            property = "type") // 'type' is the discriminator for ToolChoice
+    @JsonSubTypes({
+            @JsonSubTypes.Type(value = ToolChoiceAuto.class, name = "auto"),
+            @JsonSubTypes.Type(value = ToolChoiceAny.class, name = "any"),
+            @JsonSubTypes.Type(value = ToolChoiceTool.class, name = "tool"),
+            @JsonSubTypes.Type(value = ToolChoiceNone.class, name = "none")
+    })
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @Data
+    public static abstract class ToolChoice {
+        private String type;
+    }
+
+    @Data
+    @EqualsAndHashCode(callSuper = true)
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class ToolChoiceAuto extends ToolChoice {
+        public String getType() {
+            return "auto";
+        }
+    }
+
+    @Data
+    @EqualsAndHashCode(callSuper = true)
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class ToolChoiceAny extends ToolChoice {
+        public String getType() {
+            return "any";
+        }
+    }
+
+    @Data
+    @EqualsAndHashCode(callSuper = true)
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class ToolChoiceNone extends ToolChoice {
+        public String getType() {
+            return "none";
+        }
+    }
+
+    @Data
+    @NoArgsConstructor
+    @EqualsAndHashCode(callSuper = true)
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class ToolChoiceTool extends ToolChoice {
+        private String name;
+        public String getType() {
+            return "tool";
+        }
+    }
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class Tool {
+        private String name;
+        private String description;
+        @JsonProperty("input_schema")
+        private InputSchema inputSchema;
+    }
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class InputSchema {
+        private String type; // e.g., "object"
+        private Object properties;
+        private List<String> required;
+        private boolean additionalProperties;
+    }
+
+
+    public static class SystemFieldDeserializer extends StdDeserializer<Object> {
+        public SystemFieldDeserializer() {
+            this(null);
+        }
+        public SystemFieldDeserializer(Class<?> vc) {
+            super(vc);
+        }
+        @Override
+        public Object deserialize(JsonParser p, DeserializationContext ctxt)
+                throws IOException {
+            JsonNode node = p.getCodec().readTree(p);
+
+            if(node.isTextual()) {
+                return node.asText();
+            } else if(node.isArray()) {
+                ObjectMapper mapper = (ObjectMapper) p.getCodec();
+                return mapper.convertValue(node, new TypeReference<List<RequestTextBlock>>() {});
+
+            } else {
+                throw new JsonMappingException(p, "System field must be either String or List<RequestTextBlock>");
+            }
+        }
+    }
+
+    public static class ContentFieldDeserializer extends StdDeserializer<Object> {
+        public ContentFieldDeserializer() {
+            this(null);
+        }
+        public ContentFieldDeserializer(Class<?> vc) {
+            super(vc);
+        }
+        @Override
+        public Object deserialize(JsonParser p, DeserializationContext ctxt)
+                throws IOException {
+            JsonNode node = p.getCodec().readTree(p);
+
+            if(node.isTextual()) {
+                return node.asText();
+            } else if(node.isArray()) {
+                ObjectMapper mapper = (ObjectMapper) p.getCodec();
+                return mapper.convertValue(node, new TypeReference<List<ContentBlock>>() {});
+
+            } else {
+                throw new JsonMappingException(p, "Content field must be either String or List<ContentBlock>");
+            }
+        }
+    }
+}

--- a/api/sdk/src/main/java/com/ke/bella/openapi/protocol/message/MessageResponse.java
+++ b/api/sdk/src/main/java/com/ke/bella/openapi/protocol/message/MessageResponse.java
@@ -1,0 +1,274 @@
+package com.ke.bella.openapi.protocol.message;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+import java.util.Map;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@JsonInclude(JsonInclude.Include.ALWAYS)
+public class MessageResponse {
+    private String id;
+    private String type; // "message"
+    private String role; // "assistant"
+    private List<ContentBlock> content;
+    private String model;
+    @JsonProperty("stop_reason")
+    private String stopReason;
+    @JsonProperty("stop_sequence")
+    private String stopSequence; // Nullable
+    private Usage usage;
+
+    // Base ContentBlock for response
+    @JsonTypeInfo(
+            use = JsonTypeInfo.Id.NAME,
+            include = JsonTypeInfo.As.PROPERTY,
+            property = "type")
+    @JsonSubTypes({
+            @JsonSubTypes.Type(value = ResponseTextBlock.class, name = "text"),
+            @JsonSubTypes.Type(value = ResponseToolUseBlock.class, name = "tool_use"),
+            @JsonSubTypes.Type(value = ResponseServerToolUseBlock.class, name = "server_tool_use"),
+            @JsonSubTypes.Type(value = ResponseWebSearchToolResultBlock.class, name = "web_search_tool_result"),
+            @JsonSubTypes.Type(value = ResponseCodeExecutionToolResultBlock.class, name = "code_execution_tool_result"),
+            @JsonSubTypes.Type(value = ResponseMCPToolUseBlock.class, name = "mcp_tool_use"),
+            @JsonSubTypes.Type(value = ResponseMCPToolResultBlock.class, name = "mcp_tool_result"),
+            @JsonSubTypes.Type(value = ResponseContainerUploadBlock.class, name = "container_upload"),
+            @JsonSubTypes.Type(value = ResponseThinkingBlock.class, name = "thinking"),
+            @JsonSubTypes.Type(value = ResponseRedactedThinkingBlock.class, name = "redacted_thinking")
+            // Note: The spec also implies a generic "tool_result" which might be an abstract type
+            // or handled by specific tool result types. For now, specific ones are listed.
+    })
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @Data
+    public static abstract class ContentBlock {
+        private String type;
+    }
+
+    @Data
+    @NoArgsConstructor
+    @EqualsAndHashCode(callSuper = true)
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class ResponseTextBlock extends ContentBlock {
+        private String text;
+
+        public ResponseTextBlock(String text) {
+            this.text = text;
+        }
+    }
+
+    @Data
+    @NoArgsConstructor
+    @EqualsAndHashCode(callSuper = true)
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class ResponseToolUseBlock extends ContentBlock {
+        private String id; // tool_use_id
+        private String name;
+        private Map<String, Object> input;
+
+        public ResponseToolUseBlock(String id, String name, Map<String, Object> input) {
+            this.id = id;
+            this.name = name;
+            this.input = input;
+        }
+    }
+
+    @Data
+    @NoArgsConstructor
+    @EqualsAndHashCode(callSuper = true)
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class ResponseServerToolUseBlock extends ContentBlock {
+        @JsonProperty("tool_use_id")
+        private String toolUseId;
+        private String name;
+        private Map<String, Object> input;
+         public ResponseServerToolUseBlock(String toolUseId, String name, Map<String, Object> input) {
+            this.toolUseId = toolUseId;
+            this.name = name;
+            this.input = input;
+        }
+    }
+
+    // Abstract base for tool results if common fields exist, or directly implement specifics
+    // For now, let's assume specific tool result blocks
+
+    @Data
+    @NoArgsConstructor
+    @EqualsAndHashCode(callSuper = true)
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class ResponseWebSearchToolResultBlock extends ContentBlock {
+        @JsonProperty("tool_use_id")
+        private String toolUseId;
+        private List<Map<String, Object>> documents; // Define Document class if structure is complex/known
+        @JsonProperty("is_error")
+        private Boolean isError;
+
+
+        public ResponseWebSearchToolResultBlock(String toolUseId, List<Map<String, Object>> documents, Boolean isError) {
+            this.toolUseId = toolUseId;
+            this.documents = documents;
+            this.isError = isError;
+        }
+    }
+
+    @Data
+    @NoArgsConstructor
+    @EqualsAndHashCode(callSuper = true)
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class ResponseCodeExecutionToolResultBlock extends ContentBlock {
+        @JsonProperty("tool_use_id")
+        private String toolUseId;
+        private String stdout;
+        private String stderr;
+        @JsonProperty("is_error")
+        private Boolean isError;
+
+        public ResponseCodeExecutionToolResultBlock(String toolUseId, String stdout, String stderr, Boolean isError) {
+            this.toolUseId = toolUseId;
+            this.stdout = stdout;
+            this.stderr = stderr;
+            this.isError = isError;
+        }
+    }
+
+    @Data
+    @NoArgsConstructor
+    @EqualsAndHashCode(callSuper = true)
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class ResponseMCPToolUseBlock extends ContentBlock {
+        @JsonProperty("tool_use_id")
+        private String toolUseId;
+        private String name;
+        private Map<String, Object> input;
+
+        public ResponseMCPToolUseBlock(String toolUseId, String name, Map<String, Object> input) {
+            this.toolUseId = toolUseId;
+            this.name = name;
+            this.input = input;
+        }
+    }
+
+    @Data
+    @NoArgsConstructor
+    @EqualsAndHashCode(callSuper = true)
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class ResponseMCPToolResultBlock extends ContentBlock {
+        @JsonProperty("tool_use_id")
+        private String toolUseId;
+        private String output; // Assuming string output, adjust if complex
+        @JsonProperty("is_error")
+        private Boolean isError;
+
+        public ResponseMCPToolResultBlock(String toolUseId, String output, Boolean isError) {
+            this.toolUseId = toolUseId;
+            this.output = output;
+            this.isError = isError;
+        }
+    }
+
+    @Data
+    @NoArgsConstructor
+    @EqualsAndHashCode(callSuper = true)
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class ResponseContainerUploadBlock extends ContentBlock {
+        @JsonProperty("tool_use_id")
+        private String toolUseId;
+        @JsonProperty("container_name")
+        private String containerName;
+        @JsonProperty("file_name")
+        private String fileName;
+        @JsonProperty("full_path")
+        private String fullPath;
+        @JsonProperty("object_name")
+        private String objectName;
+        private String status; // e.g., "success", "failure"
+        private String message; // Optional message
+
+        public ResponseContainerUploadBlock(String toolUseId, String containerName, String fileName, String fullPath, String objectName, String status, String message) {
+            this.toolUseId = toolUseId;
+            this.containerName = containerName;
+            this.fileName = fileName;
+            this.fullPath = fullPath;
+            this.objectName = objectName;
+            this.status = status;
+            this.message = message;
+        }
+    }
+
+    @Data
+    @EqualsAndHashCode(callSuper = true)
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @NoArgsConstructor
+    public static class ResponseThinkingBlock extends ContentBlock {
+        private String thinking;
+
+        public ResponseThinkingBlock(String thinking) {
+            this.thinking = thinking;
+        }
+    }
+
+    @Data
+    @EqualsAndHashCode(callSuper = true)
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class ResponseRedactedThinkingBlock extends ContentBlock {
+        // Similar to ThinkingBlock, usually a marker.
+         public ResponseRedactedThinkingBlock() {
+        }
+    }
+
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class Usage {
+        @JsonProperty("input_tokens")
+        private int inputTokens;
+        @JsonProperty("output_tokens")
+        private int outputTokens;
+        @JsonProperty("cache_creation")
+        private CacheCreation cacheCreation; // Nullable
+        @JsonProperty("cache_creation_input_tokens")
+        private Integer cacheCreationInputTokens; // Nullable
+        @JsonProperty("cache_read_input_tokens")
+        private Integer cacheReadInputTokens; // Nullable
+        @JsonProperty("server_tool_use")
+        private ServerToolUsage serverToolUse; // Nullable
+        @JsonProperty("service_tier")
+        private String serviceTier; // Nullable
+    }
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class CacheCreation {
+        @JsonProperty("ephemeral_1h_input_tokens")
+        private Integer ephemeral1hInputTokens; // Using Integer for potential nullability
+        @JsonProperty("ephemeral_5m_input_tokens")
+        private Integer ephemeral5mInputTokens; // Using Integer for potential nullability
+    }
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class ServerToolUsage {
+        @JsonProperty("web_search_requests")
+        private Integer webSearchRequests; // Using Integer for potential nullability
+        // Add other tool usage counts if specified, e.g. code_execution_requests
+    }
+}

--- a/api/sdk/src/main/java/com/ke/bella/openapi/protocol/message/StreamMessageResponse.java
+++ b/api/sdk/src/main/java/com/ke/bella/openapi/protocol/message/StreamMessageResponse.java
@@ -1,0 +1,222 @@
+package com.ke.bella.openapi.protocol.message;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.ke.bella.openapi.protocol.completion.StreamCompletionResponse;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+import java.util.Collections;
+import java.util.UUID;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder(toBuilder = true) // toBuilder=true allows easy modification for factory methods
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class StreamMessageResponse {
+
+    private String type;
+    private MessageResponse message;
+    private Integer index;
+    @JsonProperty("content_block")
+    private MessageResponse.ContentBlock contentBlock;
+    private Object delta; // Holds specific delta objects or MessageDeltaInfo
+    private StreamErrorInfo error;
+
+    // 1. Helper Static Inner Classes
+
+    @JsonTypeInfo(
+            use = JsonTypeInfo.Id.NAME,
+            include = JsonTypeInfo.As.PROPERTY,
+            property = "type" // This 'type' is specific to the delta object itself
+    )
+    @JsonSubTypes({
+            @JsonSubTypes.Type(value = TextDelta.class, name = "text_delta"),
+            @JsonSubTypes.Type(value = InputJsonDelta.class, name = "input_json_delta"),
+            @JsonSubTypes.Type(value = ThinkingDelta.class, name = "thinking_delta"),
+            @JsonSubTypes.Type(value = SignatureDelta.class, name = "signature_delta")
+    })
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static abstract class Delta {
+        private String type;
+
+        public String getType() { return type; }
+        public void setType(String type) { this.type = type; }
+    }
+
+    @Data
+    @NoArgsConstructor
+    @EqualsAndHashCode(callSuper = true)
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class TextDelta extends Delta {
+        private String text;
+
+        public TextDelta(String text) {
+            this.setType("text_delta");
+            this.text = text;
+        }
+    }
+
+    @Data
+    @NoArgsConstructor
+    @EqualsAndHashCode(callSuper = true)
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class InputJsonDelta extends Delta {
+        @JsonProperty("partial_json")
+        private String partialJson;
+
+        public InputJsonDelta(String partialJson) {
+            this.setType("input_json_delta");
+            this.partialJson = partialJson;
+        }
+    }
+
+    @Data
+    @EqualsAndHashCode(callSuper = true)
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class ThinkingDelta extends Delta {
+        private String thinking;
+        public ThinkingDelta(String thinking) {
+            this.setType("thinking_delta");
+            this.thinking = thinking;
+        }
+        public ThinkingDelta() {
+            this.setType("thinking_delta");
+        }
+    }
+
+    @Data
+    @NoArgsConstructor
+    @EqualsAndHashCode(callSuper = true)
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class SignatureDelta extends Delta {
+        private String signature;
+
+        public SignatureDelta(String signature) {
+            this.setType("signature_delta");
+            this.signature = signature;
+        }
+    }
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class MessageDeltaInfo {
+        @JsonProperty("stop_reason")
+        private String stopReason;
+        @JsonProperty("stop_sequence")
+        private String stopSequence;
+        private StreamUsage usage = new StreamUsage();
+    }
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class StreamUsage {
+        @JsonProperty("input_tokens")
+        private int inputTokens;
+        @JsonProperty("output_tokens")
+        private int outputTokens;
+    }
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class StreamErrorInfo {
+        private String type;
+        private String message;
+    }
+
+    // 3. Static Factory Methods
+
+    public static StreamMessageResponse messageStart(MessageResponse initialMessage) {
+        return StreamMessageResponse.builder()
+                .type("message_start")
+                .message(initialMessage)
+                .build();
+    }
+
+    public static StreamMessageResponse contentBlockStart(int index, MessageResponse.ContentBlock block) {
+        return StreamMessageResponse.builder()
+                .type("content_block_start")
+                .index(index)
+                .contentBlock(block)
+                .build();
+    }
+
+    public static StreamMessageResponse contentBlockDelta(int index, Delta specificBlockDelta) {
+        return StreamMessageResponse.builder()
+                .type("content_block_delta")
+                .index(index)
+                .delta(specificBlockDelta)
+                .build();
+    }
+
+    public static StreamMessageResponse contentBlockStop(int index) {
+        return StreamMessageResponse.builder()
+                .type("content_block_stop")
+                .index(index)
+                .build();
+    }
+
+    public static StreamMessageResponse messageDelta(MessageDeltaInfo messageDeltaInfo) {
+        return StreamMessageResponse.builder()
+                .type("message_delta")
+                .delta(messageDeltaInfo)
+                .build();
+    }
+
+    // This is a simpler message_stop if no final message state is needed, just the type
+    public static StreamMessageResponse messageStop() {
+        return StreamMessageResponse.builder()
+                .type("message_stop")
+                .build();
+    }
+
+
+    public static StreamMessageResponse ping() {
+        return StreamMessageResponse.builder()
+                .type("ping")
+                .build();
+    }
+
+    public static StreamMessageResponse error(StreamErrorInfo errorPayload) {
+        return StreamMessageResponse.builder()
+                .type("error")
+                .error(errorPayload)
+                .build();
+    }
+
+
+    public static MessageResponse initial(StreamCompletionResponse streamCompletionResponse) {
+        String messageId = streamCompletionResponse.getId();
+        if (messageId == null || messageId.isEmpty()) {
+            messageId = UUID.randomUUID().toString();
+        }
+        MessageResponse.Usage initialUsage = MessageResponse.Usage.builder()
+                .inputTokens(1) // As per plan, initial input tokens set to 1.
+                .outputTokens(1) // As per plan, initial output tokens set to 1.
+                .build();
+        return MessageResponse.builder()
+                .id(messageId)
+                .type("message")
+                .role("assistant")
+                .content(Collections.emptyList())
+                .model(streamCompletionResponse.getModel() == null ? "LLM" : streamCompletionResponse.getModel())
+                .stopReason(null)
+                .stopSequence(null)
+                .usage(initialUsage)
+                .build();
+    }
+}

--- a/api/sdk/src/main/java/com/ke/bella/openapi/protocol/message/TransferUtils.java
+++ b/api/sdk/src/main/java/com/ke/bella/openapi/protocol/message/TransferUtils.java
@@ -1,0 +1,405 @@
+package com.ke.bella.openapi.protocol.message;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.ke.bella.openapi.protocol.completion.CompletionRequest;
+import com.ke.bella.openapi.protocol.completion.CompletionResponse;
+import com.ke.bella.openapi.protocol.completion.Message;
+import com.ke.bella.openapi.protocol.completion.StreamCompletionResponse;
+import com.ke.bella.openapi.utils.JacksonUtils;
+import lombok.Data;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.collections4.CollectionUtils;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
+
+@Slf4j
+public class TransferUtils {
+
+    //Static inner classes for Content Parts, as per OpenAI structure
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @Data
+    static class ContentPart {
+        public String type;
+        public String text;
+        public ImageUrl image_url;
+        public Object cache_control;
+
+        private ContentPart(String type) {
+            this.type = type;
+        }
+
+        public static ContentPart ofText(String text) {
+            ContentPart part = new ContentPart("text");
+            part.text = text;
+            return part;
+        }
+
+        public static ContentPart ofImageUrl(ImageUrl imageUrl) {
+            ContentPart part = new ContentPart("image_url");
+            part.image_url = imageUrl;
+            return part;
+        }
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    static class ImageUrl {
+        public String url;
+        public String detail;
+
+        public ImageUrl(String url, String detail) {
+            this.url = url;
+            this.detail = detail;
+        }
+    }
+
+    @SuppressWarnings({"unchecked", "rawTypes"})
+    public static CompletionRequest convertRequest(MessageRequest messageRequest, boolean nativeSupport) {
+        if (messageRequest == null) {
+            return null;
+        }
+
+        CompletionRequest.CompletionRequestBuilder<?, ?> builder = CompletionRequest.builder();
+
+        builder.model(messageRequest.getModel());
+        if (messageRequest.getMaxTokens() != null) {
+            builder.max_tokens(messageRequest.getMaxTokens());
+        }
+        if (messageRequest.getTemperature() != null) {
+            builder.temperature(messageRequest.getTemperature().floatValue());
+        }
+        if (messageRequest.getTopP() != null) {
+            builder.top_p(messageRequest.getTopP().floatValue());
+        }
+        if (messageRequest.getStopSequences() != null && !messageRequest.getStopSequences().isEmpty()) {
+            if (messageRequest.getStopSequences().size() == 1) {
+                builder.stop(messageRequest.getStopSequences().get(0));
+            } else {
+                builder.stop(messageRequest.getStopSequences());
+            }
+        }
+        builder.stream(messageRequest.isStream());
+
+        List<Message> chatMessages = new ArrayList<>();
+        if (messageRequest.getSystem() != null) {
+            List<Map> contentParts = new ArrayList<>();
+            if (messageRequest.getSystem() instanceof String) {
+                contentParts.add(JacksonUtils.toMap(ContentPart.ofText((String) messageRequest.getSystem())));
+            } else if (messageRequest.getSystem() instanceof List) {
+                List<MessageRequest.RequestTextBlock> systemBlocks = (List<MessageRequest.RequestTextBlock>) messageRequest.getSystem();
+                contentParts = systemBlocks.stream()
+                        .map(systemBlock -> {
+                            ContentPart contentPart = ContentPart.ofText(systemBlock.getText());
+                            if(nativeSupport) {
+                                contentPart.setCache_control(systemBlock.getCache_control());
+                            }
+                            return contentPart;
+                        })
+                        .map(JacksonUtils::toMap)
+                        .collect(Collectors.toList());
+            }
+            if (!contentParts.isEmpty()) {
+                 chatMessages.add(Message.builder().role("system").content(contentParts).build());
+            }
+        }
+
+        if (messageRequest.getMessages() != null) {
+            for (MessageRequest.InputMessage inputMessage : messageRequest.getMessages()) {
+
+                Message.MessageBuilder chatMessageBuilder = Message.builder();
+                String role = inputMessage.getRole();
+                chatMessageBuilder.role(role);
+                Object contentObj = inputMessage.getContent();
+                List<Map> contentParts = new ArrayList<>();
+                List<Message.ToolCall> toolCalls = new ArrayList<>();
+
+                List<Message.MessageBuilder> messageBuilders = new ArrayList<>();
+                messageBuilders.add(chatMessageBuilder);
+
+                if (contentObj instanceof String) {
+                    contentParts.add(JacksonUtils.toMap(ContentPart.ofText((String) contentObj)));
+                } else if (contentObj instanceof List) {
+                    List<MessageRequest.ContentBlock> contentBlocks = (List<MessageRequest.ContentBlock>) contentObj;
+                    for (MessageRequest.ContentBlock block : contentBlocks) {
+                        if (block instanceof MessageRequest.TextContentBlock) {
+                            ContentPart contentPart = ContentPart.ofText(((MessageRequest.TextContentBlock) block).getText());
+                            if(nativeSupport) {
+                                contentPart.setCache_control(block.getCache_control());
+                            }
+                            contentParts.add(JacksonUtils.toMap(contentPart));
+                        } else if (block instanceof MessageRequest.ImageContentBlock) {
+                            MessageRequest.ImageContentBlock imageBlock = (MessageRequest.ImageContentBlock) block;
+                            if (imageBlock.getSource() instanceof MessageRequest.Base64ImageSource) {
+                                MessageRequest.Base64ImageSource imageSource = (MessageRequest.Base64ImageSource) imageBlock.getSource();
+                                String dataUri = "data:" + imageSource.getMediaType() + ";base64," + imageSource.getData();
+                                ContentPart contentPart = ContentPart.ofImageUrl(new ImageUrl(dataUri, "auto"));
+                                if(nativeSupport) {
+                                    contentPart.setCache_control(block.getCache_control());
+                                }
+                                contentParts.add(JacksonUtils.toMap(contentPart));
+                            }
+                        } else if(block instanceof MessageRequest.ToolUseContentBlock) {
+                            MessageRequest.ToolUseContentBlock toolUseContentBlock = (MessageRequest.ToolUseContentBlock) block;
+                            Message.ToolCall toolCall = Message.ToolCall.fromFunctionIdAndName(toolUseContentBlock.getId(), toolUseContentBlock.getName());
+                            toolCall.setFunction(Message.FunctionCall.builder()
+                                            .name(toolUseContentBlock.getName())
+                                            .arguments(JacksonUtils.serialize(toolUseContentBlock.getInput()))
+                                            .build());
+                            toolCalls.add(toolCall);
+                        } else if (block instanceof MessageRequest.ToolResultContentBlock) {
+                            // Split tool result to different messages.
+                            // Firstly store previous content to current message, and clear the content parts.
+                            if(!contentParts.isEmpty() || !toolCalls.isEmpty()) {
+                                if (!contentParts.isEmpty()) {
+                                    messageBuilders.get(messageBuilders.size() - 1).content(contentParts);
+                                }
+                                if (!toolCalls.isEmpty()) {
+                                    messageBuilders.get(messageBuilders.size() - 1).tool_calls(toolCalls);
+                                }
+                                Message.MessageBuilder additional = Message.builder();
+                                messageBuilders.add(additional);
+                                contentParts.clear();
+                                toolCalls.clear();
+                            }
+                            Message.MessageBuilder current = messageBuilders.get(messageBuilders.size() - 1);
+                            // This assumes ToolResultContentBlock's content should also be part of the main 'content' field
+                            // when role is 'tool'. The content itself should be a string for a text part.
+                            MessageRequest.ToolResultContentBlock toolResultBlock = (MessageRequest.ToolResultContentBlock) block;
+                            current.tool_call_id(toolResultBlock.getToolUseId());
+                            current.role("tool");
+                            String toolResultStringContent = "";
+                            if (toolResultBlock.getContent() instanceof String) {
+                                toolResultStringContent = (String) toolResultBlock.getContent();
+                            } else if (toolResultBlock.getContent() != null) {
+                                toolResultStringContent = JacksonUtils.serialize(toolResultBlock.getContent());
+                            }
+                            contentParts.add(JacksonUtils.toMap(ContentPart.ofText(toolResultStringContent)));
+                        }
+                    }
+                }
+                if (!contentParts.isEmpty()) {
+                    messageBuilders.get(messageBuilders.size() - 1).content(contentParts);
+                }
+                if (!toolCalls.isEmpty()) {
+                    messageBuilders.get(messageBuilders.size() - 1).tool_calls(toolCalls);
+                }
+
+                messageBuilders.forEach(messageBuilder -> chatMessages.add(messageBuilder.build()));
+            }
+        }
+        builder.messages(chatMessages);
+
+        if (messageRequest.getTools() != null && !messageRequest.getTools().isEmpty()) {
+            List<Message.Tool> chatTools = new ArrayList<>();
+            try {
+                for (MessageRequest.Tool apiTool : messageRequest.getTools()) {
+                    Message.Function.FunctionBuilder functionBuilder = Message.Function.builder()
+                            .name(apiTool.getName())
+                            .description(apiTool.getDescription());
+                    if(apiTool.getInputSchema() != null) {
+                        MessageRequest.InputSchema schema = apiTool.getInputSchema();
+                        Message.Function.FunctionParameter.FunctionParameterBuilder paramBuilder = Message.Function.FunctionParameter.builder()
+                                .type(schema.getType())
+                                .properties(schema.getProperties())
+                                .required(schema.getRequired())
+                                .additionalProperties(schema.isAdditionalProperties());
+                        functionBuilder.parameters(paramBuilder.build());
+                    }
+                    chatTools.add(Message.Tool.builder().type("function").function(functionBuilder.build()).build());
+                }
+                builder.tools(chatTools);
+            } catch (Exception e) {
+                LOGGER.info(e.getMessage());
+            }
+        }
+
+        if (messageRequest.getToolChoice() != null) {
+            MessageRequest.ToolChoice choice = messageRequest.getToolChoice();
+            String choiceType = choice.getType(); // Common field
+            switch (choiceType) {
+                case "auto":
+                case "none":
+                    builder.tool_choice(choiceType);
+                    break;
+                case "any":
+                    builder.tool_choice("auto");
+                    break;
+                case "tool": // This corresponds to ToolChoiceTool
+                    if (choice instanceof MessageRequest.ToolChoiceTool) {
+                        MessageRequest.ToolChoiceTool toolChoiceTool = (MessageRequest.ToolChoiceTool) choice;
+                        Map<String, Object> toolChoiceMap = new HashMap<>();
+                        toolChoiceMap.put("type", "function");
+                        Map<String, String> functionDescMap = new HashMap<>();
+                        functionDescMap.put("name", toolChoiceTool.getName());
+                        toolChoiceMap.put("function", functionDescMap);
+                        builder.tool_choice(toolChoiceMap);
+                    }
+                    break;
+                default:
+                    // If it's a string type not explicitly handled, pass it through
+                    builder.tool_choice(choiceType);
+                    break;
+            }
+        }
+
+        if (messageRequest.getThinking() != null) {
+            if (messageRequest.getThinking() instanceof MessageRequest.ThinkingConfigEnabled) {
+                if(nativeSupport) {
+                    builder.reasoning_effort(messageRequest.getThinking());
+                } else {
+                    builder.enable_thinking(true);
+                    builder.reasoning_effort("medium");
+                }
+            }
+        }
+
+        return builder.build();
+    }
+
+    public static MessageResponse convertResponse(CompletionResponse chatResponse) {
+        if (chatResponse == null || chatResponse.getChoices() == null || chatResponse.getChoices().isEmpty()) {
+            return null;
+        }
+
+        MessageResponse.MessageResponseBuilder responseBuilder = MessageResponse.builder();
+        responseBuilder.id(chatResponse.getId());
+        responseBuilder.model(chatResponse.getModel());
+        responseBuilder.type("message");
+        responseBuilder.role("assistant");
+
+        CompletionResponse.Choice choice = chatResponse.getChoices().get(0);
+        Message assistantMessage = choice.getMessage();
+        List<MessageResponse.ContentBlock> contentBlocks = new ArrayList<>();
+
+        if (assistantMessage.getContent() != null) {
+            String textContent = (String) assistantMessage.getContent();
+            if (!textContent.isEmpty()) {
+                 contentBlocks.add(new MessageResponse.ResponseTextBlock(textContent));
+            }
+        }
+
+        if (assistantMessage.getTool_calls() != null && !assistantMessage.getTool_calls().isEmpty()) {
+            for (Message.ToolCall toolCall : assistantMessage.getTool_calls()) {
+                if ("function".equals(toolCall.getType())) {
+                    Map<String, Object> parsedArgs = new HashMap<>();
+                    if (toolCall.getFunction().getArguments() != null && !toolCall.getFunction().getArguments().isEmpty()) {
+                        parsedArgs = JacksonUtils.deserialize(toolCall.getFunction().getArguments(), new TypeReference<Map<String, Object>>() {});
+                    }
+                    contentBlocks.add(new MessageResponse.ResponseToolUseBlock(toolCall.getId(), toolCall.getFunction().getName(), parsedArgs));
+                }
+            }
+        }
+        responseBuilder.content(contentBlocks);
+
+        String finishReason = choice.getFinish_reason();
+        String stopReason = mapFinishReason(finishReason);
+        responseBuilder.stopReason(stopReason);
+        responseBuilder.stopSequence(null);
+
+        if (chatResponse.getUsage() != null) {
+            CompletionResponse.TokenUsage sourceUsage = chatResponse.getUsage();
+            MessageResponse.Usage usage = MessageResponse.Usage.builder()
+                    .inputTokens(sourceUsage.getPrompt_tokens())
+                    .outputTokens(sourceUsage.getCompletion_tokens())
+                    .build();
+            responseBuilder.usage(usage);
+        }
+
+        return responseBuilder.build();
+    }
+
+    public static StreamMessageResponse convertStreamResponse(StreamCompletionResponse streamChatResponse) {
+        if (streamChatResponse == null) return null;
+
+        if(CollectionUtils.isNotEmpty(streamChatResponse.getChoices())) {
+            StreamCompletionResponse.Choice streamChoice = streamChatResponse.getChoices().get(0);
+            Message delta = streamChoice.getDelta();
+            String finishReasonStr = streamChoice.getFinish_reason();
+            int choiceIndex = streamChoice.getIndex(); // Typically 0 for non-parallel choices
+
+            //Thinking content delta
+            if(delta != null && delta.getReasoning_content() != null) {
+                String reasoningContent = delta.getReasoning_content();
+                if(!reasoningContent.isEmpty()) {
+                    return StreamMessageResponse.contentBlockDelta(choiceIndex, new StreamMessageResponse.ThinkingDelta(reasoningContent));
+                }
+            }
+
+            // Text content delta
+            if(delta != null && delta.getContent() != null) {
+                String textContent = (String) delta.getContent();
+                if(!textContent.isEmpty()) {
+                    return StreamMessageResponse.contentBlockDelta(choiceIndex, new StreamMessageResponse.TextDelta(textContent));
+                }
+            }
+
+            // Tool call delta (start or argument delta)
+            if(delta != null && CollectionUtils.isNotEmpty(delta.getTool_calls())) {
+                Message.ToolCall toolCallChunk = delta.getTool_calls().get(0);
+                int toolContentBlockIndex = toolCallChunk.getIndex(); // This is the index for the content block (tool_use)
+
+                if(toolCallChunk.getFunction() != null && toolCallChunk.getFunction().getName() != null) { // Start of a new tool call
+                    return StreamMessageResponse.contentBlockStart(toolContentBlockIndex,
+                            new MessageResponse.ResponseToolUseBlock(toolCallChunk.getId(), toolCallChunk.getFunction().getName(), new HashMap<>()));
+                } else if(toolCallChunk.getFunction() != null && toolCallChunk.getFunction().getArguments() != null) { // Delta for arguments
+                    return StreamMessageResponse.contentBlockDelta(toolContentBlockIndex,
+                            new StreamMessageResponse.InputJsonDelta(toolCallChunk.getFunction().getArguments()));
+                }
+            }
+            // Finish reason
+            if(finishReasonStr != null) {
+                StreamMessageResponse.StreamUsage streamUsage = null;
+                if(streamChatResponse.getUsage() != null) { // Full usage might be on the LAST chunk with finish_reason
+                    streamUsage = StreamMessageResponse.StreamUsage.builder()
+                            .outputTokens(streamChatResponse.getUsage().getCompletion_tokens())
+                            .build();
+                } else { // More typical for intermediate deltas, no usage reported per token
+                    streamUsage = StreamMessageResponse.StreamUsage.builder().outputTokens(0).build();
+                }
+
+                String mappedStopReason = mapFinishReason(finishReasonStr);
+
+                StreamMessageResponse.MessageDeltaInfo messageInfo = StreamMessageResponse.MessageDeltaInfo.builder()
+                        .stopReason(mappedStopReason)
+                        .usage(streamUsage)
+                        .build();
+
+                return StreamMessageResponse.messageDelta(messageInfo);
+            }
+        }
+
+        //token usage
+        if (streamChatResponse.getUsage() != null) {
+            StreamMessageResponse.StreamUsage streamUsage = StreamMessageResponse.StreamUsage.builder()
+                    .outputTokens(streamChatResponse.getUsage().getCompletion_tokens())
+                    .inputTokens(streamChatResponse.getUsage().getPrompt_tokens())
+                    .build();
+            StreamMessageResponse.MessageDeltaInfo messageInfo = StreamMessageResponse.MessageDeltaInfo.builder()
+                    .usage(streamUsage)
+                    .stopReason("end_turn")
+                    .build();
+            return StreamMessageResponse.messageDelta(messageInfo);
+        }
+
+        return null;
+    }
+
+    private static String mapFinishReason(String finishReason) {
+        if (finishReason == null) return null;
+        switch (finishReason.toLowerCase()) {
+            case "stop": return "end_turn";
+            case "length": return "max_tokens";
+            case "tool_calls":
+            case "function_call":
+                return "tool_use";
+            case "content_filter": return "refusal";
+            default: return finishReason;
+        }
+    }
+}

--- a/api/sdk/src/main/java/com/ke/bella/openapi/simulation/PythonFuncCallListener.java
+++ b/api/sdk/src/main/java/com/ke/bella/openapi/simulation/PythonFuncCallListener.java
@@ -33,6 +33,7 @@ public class PythonFuncCallListener {
     }
 
     public void onFunctionCallEnter() {
+        currentToolCall.getFunction().setName(null);
         currentToolCall.getFunction().setArguments("{");
         if(callback != null) {
             callback.onMessage(StreamCompletionResponse.builder()
@@ -42,6 +43,7 @@ public class PythonFuncCallListener {
     }
 
     public void onArgumentName(String name) {
+        currentToolCall.getFunction().setName(null);
         if(callback != null) {
             currentToolCall.getFunction().setArguments(JacksonUtils.serialize(name));
             callback.onMessage(StreamCompletionResponse.builder()
@@ -53,6 +55,7 @@ public class PythonFuncCallListener {
     }
 
     public void onArgumentValue(Object value) {
+        currentToolCall.getFunction().setName(null);
         String tmp = ":" + JacksonUtils.serialize(value);
         if(callback != null) {
             currentToolCall.getFunction().setArguments(tmp);
@@ -66,6 +69,7 @@ public class PythonFuncCallListener {
     }
 
     public void onNextArgumentEnter() {
+        currentToolCall.getFunction().setName(null);
         if(callback != null) {
             currentToolCall.getFunction().setArguments(",");
             callback.onMessage(StreamCompletionResponse.builder()
@@ -77,6 +81,7 @@ public class PythonFuncCallListener {
     }
 
     public void onFunctionCallExit() {
+
         if(callback != null) {
             currentToolCall.getFunction().setArguments("}");
             callback.onMessage(StreamCompletionResponse.builder()

--- a/api/server/src/main/java/com/ke/bella/openapi/endpoints/ChatController.java
+++ b/api/server/src/main/java/com/ke/bella/openapi/endpoints/ChatController.java
@@ -58,8 +58,7 @@ public class ChatController {
     private JobQueueService jobQueueService;
     @Value("${bella.openapi.max-models-per-request:3}")
     private Integer maxModelsPerRequest;
-    
-    @SuppressWarnings({ "rawtypes", "unchecked" })
+
     @PostMapping("/completions")
     public Object completion(@RequestBody CompletionRequest request) {
         String endpoint = EndpointContext.getRequest().getRequestURI();
@@ -104,7 +103,8 @@ public class ChatController {
         // Single model processing
         return processCompletionRequest(endpoint, model, request);
     }
-    
+
+    @SuppressWarnings({ "rawtypes", "unchecked" })
     private Object processCompletionRequest(String endpoint, String model, CompletionRequest request) {
         EndpointContext.setEndpointData(endpoint, model, request);
         boolean isMock = EndpointContext.getProcessData().isMock();

--- a/api/server/src/main/java/com/ke/bella/openapi/endpoints/MessageController.java
+++ b/api/server/src/main/java/com/ke/bella/openapi/endpoints/MessageController.java
@@ -1,0 +1,75 @@
+package com.ke.bella.openapi.endpoints;
+
+import com.ke.bella.openapi.EndpointContext;
+import com.ke.bella.openapi.EndpointProcessData;
+import com.ke.bella.openapi.annotations.EndpointAPI;
+import com.ke.bella.openapi.common.exception.BizParamCheckException;
+import com.ke.bella.openapi.common.exception.ChannelException;
+import com.ke.bella.openapi.protocol.AdaptorManager;
+import com.ke.bella.openapi.protocol.ChannelRouter;
+import com.ke.bella.openapi.protocol.completion.CompletionProperty;
+import com.ke.bella.openapi.protocol.completion.callback.StreamCallbackProvider;
+import com.ke.bella.openapi.protocol.limiter.LimiterManager;
+import com.ke.bella.openapi.protocol.log.EndpointLogger;
+import com.ke.bella.openapi.protocol.message.MessageAdaptor;
+import com.ke.bella.openapi.protocol.message.MessageRequest;
+import com.ke.bella.openapi.protocol.message.MessageResponse;
+import com.ke.bella.openapi.safety.ISafetyCheckService;
+import com.ke.bella.openapi.service.JobQueueService;
+import com.ke.bella.openapi.tables.pojos.ChannelDB;
+import com.ke.bella.openapi.utils.JacksonUtils;
+import com.ke.bella.openapi.utils.SseHelper;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@EndpointAPI
+@RestController
+@RequestMapping("/v1/messages")
+@Tag(name = "messages")
+@Slf4j
+public class MessageController {
+    @Autowired
+    private ChannelRouter router;
+    @Autowired
+    private AdaptorManager adaptorManager;
+    @Autowired
+    private LimiterManager limiterManager;
+    @Autowired
+    private EndpointLogger logger;
+    @Autowired
+    private ISafetyCheckService.IChatSafetyCheckService safetyCheckService;
+
+    @PostMapping
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    public Object message(@RequestBody MessageRequest request) {
+        String endpoint = EndpointContext.getRequest().getRequestURI();
+        String model = request.getModel();
+        EndpointContext.setEndpointData(endpoint, model, request);
+        boolean isMock = EndpointContext.getProcessData().isMock();
+        ChannelDB channel = router.route(endpoint, model, EndpointContext.getApikey(), isMock);
+        EndpointContext.setEndpointData(channel);
+        if(!EndpointContext.getProcessData().isPrivate()) {
+            limiterManager.incrementConcurrentCount(EndpointContext.getProcessData().getAkCode(), model);
+        }
+        EndpointProcessData processData = EndpointContext.getProcessData();
+        String protocol = processData.getProtocol();
+        String url = processData.getForwardUrl();
+        String channelInfo = channel.getChannelInfo();
+        MessageAdaptor adaptor = adaptorManager.getProtocolAdaptor(endpoint, protocol, MessageAdaptor.class);
+        CompletionProperty property = (CompletionProperty) JacksonUtils.deserialize(channelInfo, adaptor.getPropertyClass());
+        EndpointContext.setEncodingType(property.getEncodingType());
+        if(request.isStream()) {
+            SseEmitter sse = SseHelper.createSse(1000L * 60 * 5, EndpointContext.getProcessData().getRequestId());
+            adaptor.streamMessages(request, url, property, processData, StreamCallbackProvider.provideForMessage(sse, processData, EndpointContext.getApikey(), logger, safetyCheckService, property));
+            return sse;
+        }
+        return adaptor.createMessages(request, url, property, processData);
+    }
+}

--- a/api/server/src/main/java/com/ke/bella/openapi/intercept/AuthorizationInterceptor.java
+++ b/api/server/src/main/java/com/ke/bella/openapi/intercept/AuthorizationInterceptor.java
@@ -44,7 +44,7 @@ public class AuthorizationInterceptor extends HandlerInterceptorAdapter {
             EndpointContext.setApikey(apikeyInfo);
             hasPermission = apikeyInfo.hasPermission(url);
         } else {
-            String auth = request.getHeader(HttpHeaders.AUTHORIZATION);
+            String auth = request.getHeader(getHeader(request.getRequestURI()));
             if(StringUtils.isEmpty(auth)) {
                 throw new ChannelException.AuthorizationException("Authorization is empty");
             }
@@ -56,5 +56,10 @@ public class AuthorizationInterceptor extends HandlerInterceptorAdapter {
             throw new ChannelException.AuthorizationException("没有操作权限");
         }
         return true;
+    }
+
+
+    private String getHeader(String uri) {
+        return HttpHeaders.AUTHORIZATION;
     }
 }

--- a/api/server/src/main/java/com/ke/bella/openapi/intercept/EndpointResponseAdvice.java
+++ b/api/server/src/main/java/com/ke/bella/openapi/intercept/EndpointResponseAdvice.java
@@ -36,16 +36,18 @@ public class EndpointResponseAdvice implements ResponseBodyAdvice<Object> {
     @Override
     public Object beforeBodyWrite(Object body, MethodParameter returnType, MediaType selectedContentType,
             Class<? extends HttpMessageConverter<?>> selectedConverterType, ServerHttpRequest request, ServerHttpResponse response) {
-        OpenapiResponse openapiResponse = body instanceof OpenapiResponse ? (OpenapiResponse) body :new OpenapiResponse();
-        String requestId = EndpointContext.getProcessData().getRequestId();
-        if(openapiResponse.getError() == null) {
-            response.setStatusCode(HttpStatus.OK);
-        } else {
-            Integer httpCode = openapiResponse.getError().getHttpCode();
-            response.setStatusCode(httpCode == null ? HttpStatus.SERVICE_UNAVAILABLE : HttpStatus.valueOf(httpCode));
-            logError(httpCode, requestId, openapiResponse.getError().getMessage(), null);
+        if(EndpointContext.getProcessData().getResponse() == null) {
+            OpenapiResponse openapiResponse = body instanceof OpenapiResponse ? (OpenapiResponse) body : new OpenapiResponse();
+            String requestId = EndpointContext.getProcessData().getRequestId();
+            if(openapiResponse.getError() == null) {
+                response.setStatusCode(HttpStatus.OK);
+            } else {
+                Integer httpCode = openapiResponse.getError().getHttpCode();
+                response.setStatusCode(httpCode == null ? HttpStatus.SERVICE_UNAVAILABLE : HttpStatus.valueOf(httpCode));
+                logError(httpCode, requestId, openapiResponse.getError().getMessage(), null);
+            }
+            EndpointContext.getProcessData().setResponse(openapiResponse);
         }
-        EndpointContext.getProcessData().setResponse(openapiResponse);
         logger.log(EndpointContext.getProcessData());
         return body;
     }

--- a/api/server/src/main/java/com/ke/bella/openapi/protocol/completion/callback/StreamCallbackProvider.java
+++ b/api/server/src/main/java/com/ke/bella/openapi/protocol/completion/callback/StreamCallbackProvider.java
@@ -17,4 +17,13 @@ public class StreamCallbackProvider {
         root.addLast(new StreamCompletionCallback(sse, processData, apikeyInfo, logger, safetyService));
         return root;
     }
+
+    public static Callbacks.StreamCompletionCallback provideForMessage(SseEmitter sse, EndpointProcessData processData, ApikeyInfo apikeyInfo,
+            EndpointLogger logger, ISafetyCheckService.IChatSafetyCheckService safetyService, CompletionProperty property) {
+        Callbacks.StreamCompletionCallbackNode root = new SplitReasoningCallback(property);
+        root.addLast(new ToolCallSimulatorCallback(processData));
+        root.addLast(new MergeReasoningCallback(property));
+        root.addLast(new StreamMessagesCallback(sse, processData, apikeyInfo, logger, safetyService));
+        return root;
+    }
 }

--- a/api/server/src/main/java/com/ke/bella/openapi/protocol/completion/callback/StreamCompletionCallback.java
+++ b/api/server/src/main/java/com/ke/bella/openapi/protocol/completion/callback/StreamCompletionCallback.java
@@ -28,7 +28,7 @@ import java.util.Map;
 @Slf4j
 public class StreamCompletionCallback implements Callbacks.StreamCompletionCallback {
     @Getter
-    private final SseEmitter sse;
+    protected final SseEmitter sse;
     private final EndpointProcessData processData;
     private final ApikeyInfo apikeyInfo;
     private final EndpointLogger logger;
@@ -98,7 +98,7 @@ public class StreamCompletionCallback implements Callbacks.StreamCompletionCallb
         }
     }
 
-    private void updateBuffer(StreamCompletionResponse streamResponse) {
+    protected void updateBuffer(StreamCompletionResponse streamResponse) {
         ResponseHelper.overwrite(responseBuffer, streamResponse);
         if(CollectionUtils.isEmpty(streamResponse.getChoices()) || streamResponse.getChoices().get(0).getDelta() == null) {
             return;

--- a/api/server/src/main/java/com/ke/bella/openapi/protocol/completion/callback/StreamMessagesCallback.java
+++ b/api/server/src/main/java/com/ke/bella/openapi/protocol/completion/callback/StreamMessagesCallback.java
@@ -1,0 +1,69 @@
+package com.ke.bella.openapi.protocol.completion.callback;
+
+import com.ke.bella.openapi.EndpointProcessData;
+import com.ke.bella.openapi.apikey.ApikeyInfo;
+import com.ke.bella.openapi.protocol.completion.StreamCompletionResponse;
+import com.ke.bella.openapi.protocol.log.EndpointLogger;
+import com.ke.bella.openapi.protocol.message.MessageResponse;
+import com.ke.bella.openapi.protocol.message.StreamMessageResponse;
+import com.ke.bella.openapi.protocol.message.TransferUtils;
+import com.ke.bella.openapi.safety.ISafetyCheckService;
+import com.ke.bella.openapi.utils.DateTimeUtils;
+import com.ke.bella.openapi.utils.SseHelper;
+import org.apache.commons.collections4.CollectionUtils;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+public class StreamMessagesCallback extends StreamCompletionCallback {
+
+    private boolean first = true;
+
+    private Integer curIndex = -1;
+
+    public StreamMessagesCallback(SseEmitter sse,
+            EndpointProcessData processData, ApikeyInfo apikeyInfo,
+            EndpointLogger logger,
+            ISafetyCheckService.IChatSafetyCheckService safetyService) {
+        super(sse, processData, apikeyInfo, logger, safetyService);
+    }
+
+    @Override
+    public void callback(StreamCompletionResponse msg) {
+        msg.setCreated(DateTimeUtils.getCurrentSeconds());
+        StreamMessageResponse message = TransferUtils.convertStreamResponse(msg);
+        if(message != null) {
+            if(first) {
+                send(StreamMessageResponse.messageStart(StreamMessageResponse.initial(msg)));
+                first = false;
+            }
+            if(CollectionUtils.isNotEmpty(msg.getChoices())) {
+                StreamCompletionResponse.Choice streamChoice = msg.getChoices().get(0);
+                if(curIndex != streamChoice.getIndex()) {
+                    if(!message.getType().equals("content_block_start")) {
+                        MessageResponse.ContentBlock contentBlock;
+                        if(streamChoice.getDelta().getReasoning_content() != null) {
+                            contentBlock = new MessageResponse.ResponseThinkingBlock("");
+                        } else {
+                            contentBlock = new MessageResponse.ResponseTextBlock("");
+                        }
+                        send(StreamMessageResponse.contentBlockStart(streamChoice.getIndex(), contentBlock));
+                    }
+                    curIndex = streamChoice.getIndex();
+                } else if(streamChoice.getFinish_reason() != null) {
+                    send(StreamMessageResponse.contentBlockStop(curIndex));
+                }
+            }
+            send(message);
+        }
+        updateBuffer(msg.getStandardFormat() == null ? msg : msg.getStandardFormat());
+    }
+
+    @Override
+    public void done() {
+        send(StreamMessageResponse.messageStop());
+    }
+
+    private void send(StreamMessageResponse data) {
+        SseHelper.sendEvent(sse, data.getType(), data);
+    }
+
+}

--- a/api/server/src/main/java/com/ke/bella/openapi/protocol/message/AwsAdaptor.java
+++ b/api/server/src/main/java/com/ke/bella/openapi/protocol/message/AwsAdaptor.java
@@ -1,0 +1,31 @@
+package com.ke.bella.openapi.protocol.message;
+
+import com.ke.bella.openapi.protocol.completion.AwsProperty;
+import com.ke.bella.openapi.protocol.completion.CompletionAdaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component("AwsMessage")
+public class AwsAdaptor implements MessageAdaptor<AwsProperty> {
+    @Autowired
+    private com.ke.bella.openapi.protocol.completion.AwsAdaptor delegator;
+    @Override
+    public CompletionAdaptor<AwsProperty> delegator() {
+        return delegator;
+    }
+
+    @Override
+    public boolean isNativeSupport() {
+        return true;
+    }
+
+    @Override
+    public String getDescription() {
+        return "Aws协议模型服务适配/v1/message能力点";
+    }
+
+    @Override
+    public Class<?> getPropertyClass() {
+        return AwsProperty.class;
+    }
+}

--- a/api/server/src/main/java/com/ke/bella/openapi/protocol/message/MessageAdaptor.java
+++ b/api/server/src/main/java/com/ke/bella/openapi/protocol/message/MessageAdaptor.java
@@ -1,0 +1,40 @@
+package com.ke.bella.openapi.protocol.message;
+
+import com.ke.bella.openapi.EndpointProcessData;
+import com.ke.bella.openapi.protocol.Callbacks;
+import com.ke.bella.openapi.protocol.IProtocolAdaptor;
+import com.ke.bella.openapi.protocol.completion.CompletionAdaptor;
+import com.ke.bella.openapi.protocol.completion.CompletionProperty;
+import com.ke.bella.openapi.protocol.completion.CompletionResponse;
+import com.ke.bella.openapi.protocol.completion.ToolCallSimulator;
+
+public interface MessageAdaptor<T extends CompletionProperty> extends IProtocolAdaptor {
+
+    CompletionAdaptor<T> delegator();
+
+    default MessageResponse createMessages (MessageRequest request, String url, T property, EndpointProcessData processData) {
+        CompletionAdaptor<T> delegator = decorateAdaptor(delegator(), property, processData);
+        CompletionResponse completionResponse = delegator.completion(TransferUtils.convertRequest(request ,isNativeSupport()), url, property);
+        processData.setResponse(completionResponse);
+        return TransferUtils.convertResponse(completionResponse);
+    }
+
+    default void streamMessages(MessageRequest request, String url, T property, EndpointProcessData processData, Callbacks.StreamCompletionCallback callback) {
+        CompletionAdaptor<T> delegator = decorateAdaptor(delegator(), property, processData);
+        delegator.streamCompletion(TransferUtils.convertRequest(request, isNativeSupport()), url, property, callback);
+    }
+
+    @Override
+    default String endpoint() {
+        return "/v1/messages";
+    }
+
+    default CompletionAdaptor<T> decorateAdaptor(CompletionAdaptor<T> adaptor, CompletionProperty property, EndpointProcessData processData) {
+        if(property.isFunctionCallSimulate()) {
+            adaptor = new ToolCallSimulator<>(adaptor, processData);
+        }
+        return adaptor;
+    }
+
+    boolean isNativeSupport();
+}

--- a/api/server/src/main/java/com/ke/bella/openapi/protocol/message/OpenAIAdaptor.java
+++ b/api/server/src/main/java/com/ke/bella/openapi/protocol/message/OpenAIAdaptor.java
@@ -1,0 +1,32 @@
+package com.ke.bella.openapi.protocol.message;
+
+import com.ke.bella.openapi.protocol.completion.CompletionAdaptor;
+import com.ke.bella.openapi.protocol.completion.OpenAIProperty;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component("OpenAIMessage")
+public class OpenAIAdaptor implements MessageAdaptor<OpenAIProperty> {
+    @Autowired
+    private com.ke.bella.openapi.protocol.completion.OpenAIAdaptor delegator;
+
+    @Override
+    public CompletionAdaptor<OpenAIProperty> delegator() {
+        return delegator;
+    }
+
+    @Override
+    public boolean isNativeSupport() {
+        return true;
+    }
+
+    @Override
+    public String getDescription() {
+        return "Openai协议模型服务适配/v1/message能力点";
+    }
+
+    @Override
+    public Class<?> getPropertyClass() {
+        return OpenAIProperty.class;
+    }
+}

--- a/api/server/src/main/java/com/ke/bella/openapi/utils/SseHelper.java
+++ b/api/server/src/main/java/com/ke/bella/openapi/utils/SseHelper.java
@@ -29,7 +29,7 @@ public class SseHelper {
     }
 
     public static void sendEvent(SseEmitter sse, String event, Object data) {
-        send(sse, SseEmitter.event().name(event).id(event).data(data));
+        send(sse, SseEmitter.event().name(event).data(data));
     }
 
     public static void sendEvent(SseEmitter sse, Object data) {

--- a/api/server/src/test/java/com/ke/bella/openapi/endpoints/MessageControllerTest.java
+++ b/api/server/src/test/java/com/ke/bella/openapi/endpoints/MessageControllerTest.java
@@ -1,0 +1,35 @@
+package com.ke.bella.openapi.endpoints;
+
+import com.ke.bella.openapi.protocol.message.MessageRequest;
+import com.ke.bella.openapi.protocol.message.MessageResponse;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class MessageControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void testMessageEndpoint() throws Exception {
+        MessageRequest request = new MessageRequest();
+        // Set necessary fields for the request
+
+        mockMvc.perform(post("/v1/messages")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("") // Add serialized request here
+        )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data").isNotEmpty());
+    }
+}


### PR DESCRIPTION
```api/CLAUDE.md``` 为claud code执行 /init生成的code base文件。可以手动进行修改和补充。后续会基于此进行cicd的建设。

参考：
- https://docs.anthropic.com/en/api/messages
- https://docs.anthropic.com/en/docs/build-with-claude/streaming
- https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking
- https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching