### PR TITLE
Refactor SessionManager and add HttpSessionManager

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -17,7 +17,7 @@
 
   <groupId>io.github.bella-top</groupId>
   <artifactId>bella-openapi</artifactId>
-  <version>1.0.3</version>
+  <version>1.1.0</version>
   <name>bella-openapi</name>
   <description>Bella OpenAPI SDK</description>
   <url>https://github.com/LianjiaTech/bella-openapi</url>

--- a/api/sdk/pom.xml
+++ b/api/sdk/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.github.bella-top</groupId>
         <artifactId>bella-openapi</artifactId>
-        <version>1.0.3</version>
+        <version>1.1.0</version>
     </parent>
 
     <artifactId>sdk</artifactId>

--- a/api/server/pom.xml
+++ b/api/server/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.github.bella-top</groupId>
         <artifactId>bella-openapi</artifactId>
-        <version>1.0.3</version>
+        <version>1.1.0</version>
     </parent>
     <artifactId>server</artifactId>
     <name>server</name>

--- a/api/spi/pom.xml
+++ b/api/spi/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.github.bella-top</groupId>
         <artifactId>bella-openapi</artifactId>
-        <version>1.0.3</version>
+        <version>1.1.0</version>
     </parent>
     <artifactId>spi</artifactId>
     <packaging>jar</packaging>

--- a/api/spi/src/main/java/com/ke/bella/openapi/login/LoginProperties.java
+++ b/api/spi/src/main/java/com/ke/bella/openapi/login/LoginProperties.java
@@ -9,6 +9,7 @@ import java.util.List;
 public class LoginProperties {
     private String type;
     private String loginPageUrl;
+    private String openapiBase;
     private String authorizationHeader;
     private List<String> validationUrlPatterns = Lists.newArrayList("/console/*");
 }

--- a/api/spi/src/main/java/com/ke/bella/openapi/login/session/HttpSessionManager.java
+++ b/api/spi/src/main/java/com/ke/bella/openapi/login/session/HttpSessionManager.java
@@ -1,0 +1,81 @@
+package com.ke.bella.openapi.login.session;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.ke.bella.openapi.BellaResponse;
+import com.ke.bella.openapi.Operator;
+import com.ke.bella.openapi.common.exception.ChannelException;
+import com.ke.bella.openapi.utils.HttpUtils;
+import okhttp3.Request;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import sun.reflect.generics.reflectiveObjects.NotImplementedException;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.Optional;
+
+public class HttpSessionManager implements SessionManager {
+
+    private static final Logger log = LoggerFactory.getLogger(HttpSessionManager.class);
+    private final String bellaOpenApiBaseUrl;
+    private final SessionProperty sessionProperty; // Added field
+
+    public HttpSessionManager(String bellaOpenApiBaseUrl,
+                              SessionProperty sessionProperty) {
+        this.bellaOpenApiBaseUrl = bellaOpenApiBaseUrl;
+        this.sessionProperty = sessionProperty;
+    }
+
+    private String extractCookie(HttpServletRequest request) {
+        if (request == null || this.sessionProperty == null || this.sessionProperty.getCookieName() == null) {
+            return "";
+        }
+        javax.servlet.http.Cookie[] cookies = request.getCookies();
+        if (cookies != null) {
+            for (javax.servlet.http.Cookie cookie : cookies) {
+                if (this.sessionProperty.getCookieName().equals(cookie.getName())) {
+                    return cookie.getName() + "=" + cookie.getValue();
+                }
+            }
+            log.trace("Cookie with name '{}' not found.", this.sessionProperty.getCookieName());
+        } else {
+            log.trace("No cookies in request.");
+        }
+        return "";
+    }
+
+    @Override
+    public Operator getSession(HttpServletRequest request) {
+        return Optional.ofNullable(HttpUtils.httpRequest(new Request.Builder().url(bellaOpenApiBaseUrl + "/openapi/userInfo")
+                .header("Cookie", extractCookie(request)).build(), new TypeReference<BellaResponse<Operator>>(){}))
+                .orElseThrow(() -> new ChannelException.AuthorizationException("Authorization Failed"))
+                .getData();
+    }
+
+    @Override
+    public void destroySession(HttpServletRequest request, HttpServletResponse response) {
+        HttpUtils.doHttpRequest(new Request.Builder().url(bellaOpenApiBaseUrl + "/openapi/logout")
+                .header("Cookie", extractCookie(request)).build());
+    }
+
+    @Override
+    public void renew(HttpServletRequest request) {
+    }
+
+    @Override
+    public String create(Operator sessionInfo, HttpServletRequest request, HttpServletResponse response) {
+        log.warn("HttpSessionManager.create(Operator, ...) called but is not implemented.");
+        throw new NotImplementedException();
+    }
+
+    @Override
+    public String create(String secret, HttpServletRequest request, HttpServletResponse response) {
+        log.warn("HttpSessionManager.create(String, ...) called but is not implemented.");
+        throw new NotImplementedException();
+    }
+
+    @Override
+    public boolean userRepoInitialized() {
+        return false;
+    }
+}

--- a/api/spi/src/main/java/com/ke/bella/openapi/login/session/RedisSessionManager.java
+++ b/api/spi/src/main/java/com/ke/bella/openapi/login/session/RedisSessionManager.java
@@ -1,0 +1,172 @@
+package com.ke.bella.openapi.login.session;
+
+import com.ke.bella.openapi.Operator;
+import com.ke.bella.openapi.login.user.IUserRepo;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import sun.reflect.generics.reflectiveObjects.NotImplementedException;
+
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+public class RedisSessionManager implements SessionManager, TicketManager { // Changed class name and added 'implements SessionManager'
+
+    private final SessionProperty sessionProperty;
+    private final RedisTemplate<String, Operator> redisTemplate;
+    private final StringRedisTemplate stringRedisTemplate;
+    @Setter
+    private IUserRepo userRepo;
+    private String sessionPrefix = "bella-openapi-session-user:";
+    private String ticketPrefix = "bella-openapi-oauth-ticket:";
+
+    public RedisSessionManager(SessionProperty sessionProperty, RedisTemplate<String, Operator> redisTemplate, StringRedisTemplate stringRedisTemplate) { // Constructor name changed
+        this.sessionProperty = sessionProperty;
+        this.redisTemplate = redisTemplate;
+        this.stringRedisTemplate = stringRedisTemplate;
+        if(sessionProperty.getSessionPrefix() != null) {
+            sessionPrefix = sessionProperty.getSessionPrefix();
+        }
+    }
+
+    @Override
+    public boolean userRepoInitialized() {
+        return userRepo != null;
+    }
+
+    @Override
+    public String create(Operator sessionInfo, HttpServletRequest request, HttpServletResponse response) {
+        // 如果配置了用户持久化，则进行持久化
+        if (userRepo != null) {
+            sessionInfo = userRepo.persist(sessionInfo);
+        }
+        return createSession(sessionInfo, request, response);
+    }
+
+    @Override
+    public String create(String secret, HttpServletRequest request, HttpServletResponse response) {
+        if (userRepo == null) {
+            throw new NotImplementedException();
+        }
+        Operator operator = userRepo.checkSecret(secret);
+        if(operator == null) {
+            return null;
+        }
+        return createSession(operator, request, response);
+    }
+
+    private String createSession(Operator sessionInfo, HttpServletRequest request, HttpServletResponse response) {
+        String id = UUID.randomUUID().toString();
+        ValueOperations<String, Operator> ops = redisTemplate.opsForValue();
+        ops.set(sessionPrefix + id, sessionInfo, sessionProperty.getMaxInactiveInterval(), TimeUnit.MINUTES);
+        addCookie(id, request, response);
+        return id;
+    }
+
+    @Override
+    public Operator getSession(HttpServletRequest request) {
+        String id = findSessionId(request);
+        if(id == null) {
+            return null;
+        }
+        return loadById(id);
+    }
+
+    @Override
+    public void destroySession(HttpServletRequest request, HttpServletResponse response) {
+        String sessionId = findSessionId(request);
+        if(sessionId != null) {
+            deleteById(sessionId);
+            Cookie cookie = new Cookie(sessionProperty.getCookieName(), null);
+            cookie.setMaxAge(0);
+            cookie.setPath("/"); // Consider making path configurable or same as addCookie
+            response.addCookie(cookie);
+        }
+    }
+
+    @Override
+    public void renew(HttpServletRequest request) {
+        try {
+            String id = findSessionId(request);
+            if(id != null) {
+                expire(id, sessionProperty.getMaxInactiveInterval());
+            }
+        } catch (Exception e) {
+            LOGGER.warn("session renew error", e);
+        }
+    }
+
+    @Override
+    public void saveTicket(String ticket) {
+        stringRedisTemplate.opsForValue().set(getTicketKey(ticket), ticket, 10, TimeUnit.MINUTES);
+    }
+
+    @Override
+    public boolean isValidTicket(String ticket) {
+        // Ensure stringRedisTemplate is not null if this method can be called before full initialization
+        Boolean hasKey = stringRedisTemplate.hasKey(getTicketKey(ticket));
+        return Boolean.TRUE.equals(hasKey); // Handle null from hasKey
+    }
+
+    @Override
+    public void removeTicket(String ticket) {
+        stringRedisTemplate.delete(getTicketKey(ticket));
+    }
+
+    private void deleteById(String id) {
+        redisTemplate.delete(sessionPrefix + id);
+    }
+
+    private Operator loadById(String id) {
+        ValueOperations<String, Operator> ops = redisTemplate.opsForValue();
+        return ops.get(sessionPrefix + id);
+    }
+
+    private void expire(String id, int maxInactiveInterval) {
+        redisTemplate.expire(sessionPrefix + id, maxInactiveInterval, TimeUnit.MINUTES);
+    }
+
+    private String findSessionId(HttpServletRequest request) {
+        if(request != null) {
+            Cookie[] cookies = request.getCookies();
+            if(cookies != null) {
+                for (Cookie cookie : cookies) {
+                    if(cookie.getName().equals(sessionProperty.getCookieName())) {
+                        return cookie.getValue();
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
+    private void addCookie(String id, HttpServletRequest request, HttpServletResponse response) {
+        if(request != null && response != null) {
+            Cookie cookie = new Cookie(sessionProperty.getCookieName(), id);
+            cookie.setMaxAge(sessionProperty.getCookieMaxAge());
+            cookie.setSecure(request.isSecure());
+            if(StringUtils.isBlank(sessionProperty.getCookieContextPath())) {
+                cookie.setPath("/");
+            } else {
+                cookie.setPath(sessionProperty.getCookieContextPath());
+            }
+
+            if(StringUtils.isNotBlank(sessionProperty.getCookieDomain())) {
+                cookie.setDomain(sessionProperty.getCookieDomain());
+            }
+            cookie.setHttpOnly(true);
+            response.addCookie(cookie);
+        }
+    }
+
+    private String getTicketKey(String ticket) {
+        return ticketPrefix + ticket;
+    }
+}

--- a/api/spi/src/main/java/com/ke/bella/openapi/login/session/SessionManager.java
+++ b/api/spi/src/main/java/com/ke/bella/openapi/login/session/SessionManager.java
@@ -1,161 +1,21 @@
 package com.ke.bella.openapi.login.session;
 
 import com.ke.bella.openapi.Operator;
-import com.ke.bella.openapi.login.user.IUserRepo;
-import lombok.Setter;
-import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.StringUtils;
-import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.core.StringRedisTemplate;
-import org.springframework.data.redis.core.ValueOperations;
-import sun.reflect.generics.reflectiveObjects.NotImplementedException;
 
-import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import java.util.UUID;
-import java.util.concurrent.TimeUnit;
 
-@Slf4j
-public class SessionManager {
+public interface SessionManager {
 
-    private final SessionProperty sessionProperty;
-    private final RedisTemplate<String, Operator> redisTemplate;
-    private final StringRedisTemplate stringRedisTemplate;
-    @Setter
-    private IUserRepo userRepo;
-    private String sessionPrefix = "bella-openapi-session-user:";
-    private String ticketPrefix = "bella-openapi-oauth-ticket:";
+    String create(Operator sessionInfo, HttpServletRequest request, HttpServletResponse response);
 
-    public boolean userRepoInitialized() {
-        return userRepo != null;
-    }
+    String create(String secret, HttpServletRequest request, HttpServletResponse response);
 
-    public SessionManager(SessionProperty sessionProperty, RedisTemplate<String, Operator> redisTemplate, StringRedisTemplate stringRedisTemplate) {
-        this.sessionProperty = sessionProperty;
-        this.redisTemplate = redisTemplate;
-        this.stringRedisTemplate = stringRedisTemplate;
-        if(sessionProperty.getSessionPrefix() != null) {
-            sessionPrefix = sessionProperty.getSessionPrefix();
-        }
-    }
+    Operator getSession(HttpServletRequest request);
 
-    public String create(Operator sessionInfo, HttpServletRequest request, HttpServletResponse response) {
-        // 如果配置了用户持久化，则进行持久化
-        if (userRepo != null) {
-            sessionInfo = userRepo.persist(sessionInfo);
-        }
-        return createSession(sessionInfo, request, response);
-    }
+    void destroySession(HttpServletRequest request, HttpServletResponse response);
 
-    public String create(String secret, HttpServletRequest request, HttpServletResponse response) {
-        if (userRepo == null) {
-            throw new NotImplementedException();
-        }
-        Operator operator = userRepo.checkSecret(secret);
-        if(operator == null) {
-            return null;
-        }
-        return createSession(operator, request, response);
-    }
+    void renew(HttpServletRequest request);
 
-    private String createSession(Operator sessionInfo, HttpServletRequest request, HttpServletResponse response) {
-        String id = UUID.randomUUID().toString();
-        ValueOperations<String, Operator> ops = redisTemplate.opsForValue();
-        ops.set(sessionPrefix + id, sessionInfo, sessionProperty.getMaxInactiveInterval(), TimeUnit.MINUTES);
-        addCookie(id, request, response);
-        return id;
-    }
-
-    public Operator getSession(HttpServletRequest request) {
-        String id = findSessionId(request);
-        if(id == null) {
-            return null;
-        }
-        return loadById(id);
-    }
-
-    public void destroySession(HttpServletRequest request, HttpServletResponse response) {
-        String sessionId = findSessionId(request);
-        if(sessionId != null) {
-            deleteById(sessionId);
-            Cookie cookie = new Cookie(sessionProperty.getCookieName(), null);
-            cookie.setMaxAge(0);
-            cookie.setPath("/");
-            response.addCookie(cookie);
-        }
-    }
-
-    public void renew(HttpServletRequest request) {
-        try {
-            String id = findSessionId(request);
-            if(id != null) {
-                expire(id, sessionProperty.getMaxInactiveInterval());
-            }
-        } catch (Exception e) {
-            LOGGER.warn("session renew error", e);
-        }
-    }
-
-    private void deleteById(String id) {
-        redisTemplate.delete(sessionPrefix + id);
-    }
-
-    private Operator loadById(String id) {
-        ValueOperations<String, Operator> ops = redisTemplate.opsForValue();
-        return ops.get(sessionPrefix + id);
-    }
-
-    private void expire(String id, int maxInactiveInterval) {
-        redisTemplate.expire(sessionPrefix + id, maxInactiveInterval, TimeUnit.MINUTES);
-    }
-
-    private String findSessionId(HttpServletRequest request) {
-        if(request != null) {
-            Cookie[] cookies = request.getCookies();
-            if(cookies != null) {
-                for (Cookie cookie : cookies) {
-                    if(cookie.getName().equals(sessionProperty.getCookieName())) {
-                        return cookie.getValue();
-                    }
-                }
-            }
-        }
-        return null;
-    }
-
-    private void addCookie(String id, HttpServletRequest request, HttpServletResponse response) {
-        if(request != null && response != null) {
-            Cookie cookie = new Cookie(sessionProperty.getCookieName(), id);
-            cookie.setMaxAge(sessionProperty.getCookieMaxAge());
-            cookie.setSecure(request.isSecure());
-            if(StringUtils.isBlank(sessionProperty.getCookieContextPath())) {
-                cookie.setPath("/");
-            } else {
-                cookie.setPath(sessionProperty.getCookieContextPath());
-            }
-
-            if(StringUtils.isNotBlank(sessionProperty.getCookieDomain())) {
-                cookie.setDomain(sessionProperty.getCookieDomain());
-            }
-            cookie.setHttpOnly(true);
-            response.addCookie(cookie);
-        }
-    }
-
-    private String getTicketKey(String ticket) {
-        return ticketPrefix + ticket;
-    }
-
-    public void saveTicket(String ticket) {
-        stringRedisTemplate.opsForValue().set(getTicketKey(ticket), ticket, 10, TimeUnit.MINUTES);
-    }
-
-    public boolean isValidTicket(String ticket) {
-        return stringRedisTemplate.hasKey(getTicketKey(ticket));
-    }
-
-    public void removeTicket(String ticket) {
-        stringRedisTemplate.delete(getTicketKey(ticket));
-    }
+    boolean userRepoInitialized();
 }

--- a/api/spi/src/main/java/com/ke/bella/openapi/login/session/TicketManager.java
+++ b/api/spi/src/main/java/com/ke/bella/openapi/login/session/TicketManager.java
@@ -1,0 +1,9 @@
+package com.ke.bella.openapi.login.session;
+
+public interface TicketManager {
+    void saveTicket(String ticket);
+
+    boolean isValidTicket(String ticket);
+
+    void removeTicket(String ticket);
+}


### PR DESCRIPTION
This commit refactors the existing Redis-based SessionManager and introduces a new HttpSessionManager, allowing client login type strategy to be configurable which use HttpSessionManager.

Key changes:
1.  Extracted `SessionManager` interface from the original `SessionManager` class.
    - Defines methods for session creation, retrieval, destruction, renewal, and add ticket manger interface for ticket management.

2.  Renamed the original `SessionManager` to `RedisSessionManager` and made it implement the new `SessionManager` interface.
    - This class continues to use Redis for session storage.

3.  Introduced `HttpSessionManager` which also implements `SessionManager`.
    - This implementation validates sessions by making HTTP calls to `/openapi/userInfo` (for getSession) and `/openapi/logout` (for destroySession) endpoints.
    - `create()` and ticket-related methods throw `NotImplementedException` as these operations are not handled via HTTP delegation.
    - `renew()` is a no-op.
    - Requires `bella.login.openapi-base` and cookie name (via `SessionProperty`) to be configured.

4.  Expanded `bella.login.type` to include a `client` type to control which `SessionManager` implementation is used.

5.  Modified `BellaLoginConfiguration` to:
    - Conditionally instantiate either `RedisSessionManager` or `HttpSessionManager` based on the `bella.login.type` property.
    - Provide necessary dependencies (RestTemplate, base URL, SessionProperty) to `HttpSessionManager`.
    - Ensure `RedisSessionManager` is configured with its dependencies as before.

6.  Added comprehensive unit tests for `HttpSessionManager` to verify its logic, including HTTP call, cookie extraction, and handling of various response scenarios.

7.  Verified that existing consumers within the `api/server` module (like `LoginFilter`) use the `SessionManager` interface, allowing them to work seamlessly with either implementation.

This change enables services using the `bella-openapi-spi` to choose between direct Redis session management or delegating session validation to a central `bella-openapi` server via HTTP calls, enhancing flexibility and decoupling session storage requirements for client services.