### PR TITLE
 fix: optimize API key editing to use local updates instead of full p…

### DIFF
--- a/web/src/components/apikey/apikey-balance.tsx
+++ b/web/src/components/apikey/apikey-balance.tsx
@@ -16,7 +16,7 @@ interface ApiKeyBalanceIndicatorProps {
   code: string;
 }
 
-export const ApiKeyBalanceIndicator: React.FC<ApiKeyBalanceIndicatorProps> = ({ code }) => {
+export const ApiKeyBalanceIndicator: React.FC<ApiKeyBalanceIndicatorProps> = React.memo(({ code }) => {
   const [balance, setBalance] = useState<ApiKeyBalance | null>(null);
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<boolean>(false);
@@ -78,7 +78,7 @@ export const ApiKeyBalanceIndicator: React.FC<ApiKeyBalanceIndicatorProps> = ({ 
       <ApiKeyBalanceDialog code={code} isOpen={showDialog} onClose={() => setShowDialog(false)} />
     </>
   );
-};
+});
 
 export const ApiKeyBalanceDialog: React.FC<ApiKeyBalanceDialogProps> = ({
   code,

--- a/web/src/components/apikey/apikey-column.tsx
+++ b/web/src/components/apikey/apikey-column.tsx
@@ -143,7 +143,7 @@ const ActionCell = ({code, refresh, showApikey}: { code: string, refresh: () => 
     )
 }
 
-export const ApikeyColumns = (refresh: () => void, showApikey: (apikey : string) => void): ColumnDef<ApikeyInfo>[] => [
+export const ApikeyColumns = (refresh: () => void, showApikey: (apikey : string) => void, updateApiKeyInPlace?: (code: string, updates: Partial<ApikeyInfo>) => void): ColumnDef<ApikeyInfo>[] => [
     {
         accessorKey: "akDisplay",
         header: "AK",
@@ -166,6 +166,7 @@ export const ApikeyColumns = (refresh: () => void, showApikey: (apikey : string)
                         refresh={refresh}
                         isOpen={isOpen}
                         onClose={onClose}
+                        onSuccess={updateApiKeyInPlace ? (newName) => updateApiKeyInPlace(row.original.code, { name: newName }) : undefined}
                     />
                 )}
                 positionCalc="50%"
@@ -186,6 +187,7 @@ export const ApikeyColumns = (refresh: () => void, showApikey: (apikey : string)
                         refresh={refresh}
                         isOpen={isOpen}
                         onClose={onClose}
+                        onSuccess={updateApiKeyInPlace ? (newServiceId) => updateApiKeyInPlace(row.original.code, { serviceId: newServiceId }) : undefined}
                     />
                 )}
                 positionCalc="50%"

--- a/web/src/components/apikey/apikey-dialog.tsx
+++ b/web/src/components/apikey/apikey-dialog.tsx
@@ -271,8 +271,9 @@ export const RenameDialog: React.FC<{
     origin: string;
     refresh: () => void;
     isOpen: boolean;
-    onClose: () => void
-}> = ({code, origin, refresh, isOpen, onClose}) => {
+    onClose: () => void;
+    onSuccess?: (newName: string) => void;
+}> = ({code, origin, refresh, isOpen, onClose, onSuccess}) => {
     const [name, setName] = useState(origin)
     const {toast} = useToast()
 
@@ -290,7 +291,11 @@ export const RenameDialog: React.FC<{
         try {
             const success = await rename(code, name)
             if (success) {
-                refresh()
+                if (onSuccess) {
+                    onSuccess(name)
+                } else {
+                    refresh()
+                }
                 toast({title: "修改成功", description: "apikey名称修改为:" + name})
             } else {
                 setName(origin)
@@ -328,8 +333,9 @@ export const ServiceIdDialog: React.FC<{
     origin: string;
     refresh: () => void;
     isOpen: boolean;
-    onClose: () => void
-}> = ({code, origin, refresh, isOpen, onClose}) => {
+    onClose: () => void;
+    onSuccess?: (newServiceId: string) => void;
+}> = ({code, origin, refresh, isOpen, onClose, onSuccess}) => {
     const [serviceId, setServiceId] = useState(origin)
     const {toast} = useToast()
 
@@ -343,7 +349,11 @@ export const ServiceIdDialog: React.FC<{
         try {
             const success = await bindService(code, serviceId)
             if (success) {
-                refresh()
+                if (onSuccess) {
+                    onSuccess(serviceId)
+                } else {
+                    refresh()
+                }
                 toast({title: "修改成功", description: "服务ID修改为:" + serviceId})
             } else {
                 setServiceId(origin)

--- a/web/src/components/apikey/sub-apikey-column.tsx
+++ b/web/src/components/apikey/sub-apikey-column.tsx
@@ -90,7 +90,8 @@ export const SubApikeyColumns = (
     setCurrentSubApikey:(apikey:ApikeyInfo|null)=> void,
     setShowUpdateDialog:(open:boolean)=> void,
     handleCopyDialog: (apikey:string) => void,
-    refresh: () => void): ColumnDef<ApikeyInfo>[] => [
+    refresh: () => void,
+    updateApiKeyInPlace?: (code: string, updates: Partial<ApikeyInfo>) => void): ColumnDef<ApikeyInfo>[] => [
     {
         accessorKey: "akDisplay",
         header: "子AK",

--- a/web/src/components/apikey/sub-apikey-dialog.tsx
+++ b/web/src/components/apikey/sub-apikey-dialog.tsx
@@ -21,7 +21,7 @@ import {Select, SelectContent, SelectItem, SelectTrigger, SelectValue} from "@/c
 interface SubApikeyDialogProps {
     isOpen: boolean
     onClose: () => void
-    onSuccess: (apikey:string| null) => void
+    onSuccess: (apikey:string| null, isUpdate?: boolean, updatedData?: ApikeyInfo) => void
     parentApikey: ApikeyInfo,
     currentSubApikey: ApikeyInfo | null,
 }
@@ -62,7 +62,7 @@ export const SubApikeyDialog: React.FC<SubApikeyDialogProps> = ({
             monthQuota: currentSubApikey?.monthQuota || 50,
             remark: currentSubApikey?.remark || ''
         });
-    }, [currentSubApikey]);
+    }, [currentSubApikey, isOpen]);
 
     const handleInputChange = (field: keyof FormData, value: string | number) => {
         setFormData(prev => ({
@@ -128,7 +128,16 @@ export const SubApikeyDialog: React.FC<SubApikeyDialogProps> = ({
                         title: "成功",
                         description: "子API Key修改成功",
                     })
-                    onSuccess(null)
+                    // 构造更新后的数据
+                    const updatedData: ApikeyInfo = {
+                        ...currentSubApikey,
+                        name: formData.name.trim(),
+                        outEntityCode: formData.outEntityCode.trim(),
+                        safetyLevel: formData.safetyLevel,
+                        monthQuota: formData.monthQuota,
+                        remark: formData.remark.trim(),
+                    }
+                    onSuccess(null, true, updatedData)
                     // 重置表单
                     setFormData({
                         name: '',


### PR DESCRIPTION
…age refresh

 Commit Message:

  fix: optimize API key editing to use local updates instead of full page refresh

  - Replace full page refresh with local state updates when editing API key names and service IDs
  - Add React performance optimizations (React.memo, useCallback, useMemo) to prevent unnecessary re-renders
  - Implement in-place updates for both main API key page and sub API key page
  - Fix state cleanup bug in sub API key dialog when switching between create/edit modes

  Performance improvements:
  - Editing API key names now updates only the specific row instead of refreshing entire list
  - Service ID changes use local updates to avoid unnecessary API calls
  - Sub API key modifications use local updates when editing existing keys
  - Eliminated list "shaking" issue caused by unnecessary balance API calls

  Technical changes:
  - Add updateApiKeyInPlace function for targeted state updates
  - Enhance RenameDialog and ServiceIdDialog with onSuccess callbacks
  - Update SubApikeyDialog to support both create and update modes with proper state management
  - Ensure proper cleanup of currentSubApikey state when switching dialog modes