### PR TITLE
feat: cas server support client login type

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -17,7 +17,7 @@
 
   <groupId>top.bella</groupId>
   <artifactId>bella-openapi</artifactId>
-  <version>1.1.0</version>
+  <version>1.1.1</version>
   <name>bella-openapi</name>
   <description>Bella OpenAPI SDK</description>
   <url>https://github.com/LianjiaTech/bella-openapi</url>

--- a/api/sdk/pom.xml
+++ b/api/sdk/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>top.bella</groupId>
         <artifactId>bella-openapi</artifactId>
-        <version>1.1.0</version>
+        <version>1.1.1</version>
     </parent>
 
     <artifactId>openapi-sdk</artifactId>

--- a/api/sdk/src/main/java/com/ke/bella/openapi/common/exception/ChannelException.java
+++ b/api/sdk/src/main/java/com/ke/bella/openapi/common/exception/ChannelException.java
@@ -162,4 +162,25 @@ public abstract class ChannelException extends RuntimeException {
             }
         }
     }
+
+    @Getter
+    public static class ClientNotLoginException extends ChannelException {
+
+        private final String redirectUrl;
+
+        public ClientNotLoginException(String redirectUrl) {
+            super("Need to login");
+            this.redirectUrl = redirectUrl;
+        }
+
+        @Override
+        public Integer getHttpCode() {
+            return 401;
+        }
+
+        @Override
+        public String getType() {
+            return "No Login";
+        }
+    }
 }

--- a/api/server/pom.xml
+++ b/api/server/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>top.bella</groupId>
         <artifactId>bella-openapi</artifactId>
-        <version>1.1.0</version>
+        <version>1.1.1</version>
     </parent>
     <artifactId>openapi-server</artifactId>
     <name>bella-openapi-server</name>

--- a/api/server/src/main/resources/application.yml
+++ b/api/server/src/main/resources/application.yml
@@ -57,9 +57,6 @@ bella:
   login:
     authorization-header: Authorization
     login-page-url: http://localhost:3000/login
-    validation-url-patterns:
-      - /console/*
-      - /v1/meta/*
   session:
     cookie-name: bella_openapi_sessionId
     max-inactive-interval: 60

--- a/api/spi/pom.xml
+++ b/api/spi/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>top.bella</groupId>
         <artifactId>bella-openapi</artifactId>
-        <version>1.1.0</version>
+        <version>1.1.1</version>
     </parent>
     <artifactId>openapi-spi</artifactId>
     <packaging>jar</packaging>

--- a/api/spi/src/main/java/com/ke/bella/openapi/login/ClientLoginFilter.java
+++ b/api/spi/src/main/java/com/ke/bella/openapi/login/ClientLoginFilter.java
@@ -1,0 +1,28 @@
+package com.ke.bella.openapi.login;
+
+import com.ke.bella.openapi.common.exception.ChannelException;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public class ClientLoginFilter implements Filter {
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain filterChain)
+            throws IOException {
+        HttpServletResponse httpResponse = (HttpServletResponse) response;
+        try {
+            filterChain.doFilter(request, response);
+        } catch (ChannelException.ClientNotLoginException clientNotLoginException) {
+            httpResponse.setStatus(401);
+            httpResponse.setHeader(LoginFilter.REDIRECT_HEADER, clientNotLoginException.getRedirectUrl());
+        } catch (ChannelException channelException) {
+            httpResponse.sendError(channelException.getHttpCode(), channelException.getMessage());
+        } catch (Exception exception) {
+            httpResponse.sendError(500, exception.getMessage());
+        }
+    }
+}

--- a/api/spi/src/main/java/com/ke/bella/openapi/login/LoginFilter.java
+++ b/api/spi/src/main/java/com/ke/bella/openapi/login/LoginFilter.java
@@ -30,8 +30,8 @@ import static com.ke.bella.openapi.login.config.BellaLoginConfiguration.redirect
 public class LoginFilter implements Filter {
     private final LoginProperties properties;
     private final SessionManager sessionManager;
-    private static final String REDIRECT_HEADER = "X-Redirect-Login";
-    private static final String CONSOLE_HEADER = "X-BELLA-CONSOLE";
+    public static final String REDIRECT_HEADER = "X-Redirect-Login";
+    public static final String CONSOLE_HEADER = "X-BELLA-CONSOLE";
 
     public LoginFilter(LoginProperties properties, SessionManager sessionManager) {
         this.properties = properties;
@@ -112,7 +112,7 @@ public class LoginFilter implements Filter {
                 chain.doFilter(request, response);
                 return;
             }
-            if("true".equals(httpRequest.getHeader(CONSOLE_HEADER))) {
+            if("true".equals(httpRequest.getHeader(CONSOLE_HEADER)) && StringUtils.isNotBlank(properties.getLoginPageUrl())) {
                 httpResponse.setHeader(REDIRECT_HEADER, properties.getLoginPageUrl() + "?" + redirectParameter + "=");
                 httpResponse.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
                 return;

--- a/api/spi/src/main/java/com/ke/bella/openapi/login/LoginProperties.java
+++ b/api/spi/src/main/java/com/ke/bella/openapi/login/LoginProperties.java
@@ -11,5 +11,4 @@ public class LoginProperties {
     private String loginPageUrl;
     private String openapiBase;
     private String authorizationHeader;
-    private List<String> validationUrlPatterns = Lists.newArrayList("/console/*");
 }

--- a/api/spi/src/main/java/com/ke/bella/openapi/login/cas/BellaCasClient.java
+++ b/api/spi/src/main/java/com/ke/bella/openapi/login/cas/BellaCasClient.java
@@ -37,7 +37,6 @@ public class BellaCasClient {
         initParams.put(ConfigurationKeys.SERVER_NAME.getName(), casProperties.getClientHost());
         initParams.put(ConfigurationKeys.REDIRECT_AFTER_VALIDATION.getName(), String.valueOf(Boolean.FALSE));
         filterRegistrationBean.setInitParameters(initParams);
-        filterRegistrationBean.setUrlPatterns(loginProperties.getValidationUrlPatterns());
         filterRegistrationBean.getInitParameters().put(ConfigurationKeys.USE_SESSION.getName(), String.valueOf(Boolean.TRUE));
         return filterRegistrationBean;
     }
@@ -47,7 +46,6 @@ public class BellaCasClient {
         BellaRedirectFilter targetCasAuthFilter = new BellaRedirectFilter();
         filterRegistrationBean.setFilter(targetCasAuthFilter);
         filterRegistrationBean.setOrder(CAS_STEP_TWO);
-        filterRegistrationBean.setUrlPatterns(loginProperties.getValidationUrlPatterns());
         return filterRegistrationBean;
     }
 
@@ -58,7 +56,6 @@ public class BellaCasClient {
                 casProperties.getClientIndexUrl(), sessionManager);
         filterRegistrationBean.setOrder(CAS_STEP_THREE);
         filterRegistrationBean.setFilter(filter);
-        filterRegistrationBean.setUrlPatterns(loginProperties.getValidationUrlPatterns());
         return filterRegistrationBean;
     }
 }

--- a/api/spi/src/main/java/com/ke/bella/openapi/login/cas/BellaCasLoginFilter.java
+++ b/api/spi/src/main/java/com/ke/bella/openapi/login/cas/BellaCasLoginFilter.java
@@ -12,11 +12,14 @@ import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import com.ke.bella.openapi.login.LoginFilter;
 import org.apache.commons.lang3.StringUtils;
 
 import com.ke.bella.openapi.Operator;
 import com.ke.bella.openapi.login.config.BellaLoginConfiguration;
 import com.ke.bella.openapi.login.session.SessionManager;
+
+import static com.ke.bella.openapi.login.LoginFilter.CONSOLE_HEADER;
 
 public class BellaCasLoginFilter implements Filter {
     private final String loginUrl;
@@ -52,6 +55,10 @@ public class BellaCasLoginFilter implements Filter {
                 return;
             }
         }
+        if(!"true".equals(httpRequest.getHeader(CONSOLE_HEADER))) {
+            chain.doFilter(request, response);
+            return;
+        }
         Operator operator = sessionManager.getSession(httpRequest);
         if(operator == null) {
             HttpServletResponse httpResponse = (HttpServletResponse) response;
@@ -66,7 +73,7 @@ public class BellaCasLoginFilter implements Filter {
             loginBuilder.append(encodedService);
             if(clientSupport) {
                 httpResponse.setStatus(401);
-                httpResponse.setHeader("X-Redirect-Login", loginBuilder.toString());
+                httpResponse.setHeader(LoginFilter.REDIRECT_HEADER, loginBuilder.toString());
             } else {
                 httpResponse.sendRedirect(loginBuilder.toString());
             }

--- a/api/spi/src/main/java/com/ke/bella/openapi/login/config/ConditionalOnClientEnable.java
+++ b/api/spi/src/main/java/com/ke/bella/openapi/login/config/ConditionalOnClientEnable.java
@@ -1,0 +1,32 @@
+package com.ke.bella.openapi.login.config;
+
+import org.springframework.boot.autoconfigure.condition.ConditionOutcome;
+import org.springframework.boot.autoconfigure.condition.SpringBootCondition;
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.core.type.AnnotatedTypeMetadata;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Conditional(ConditionalOnClientEnable.ClientEnableCondition.class)
+public @interface ConditionalOnClientEnable {
+    class ClientEnableCondition extends SpringBootCondition {
+        @Override
+        public ConditionOutcome getMatchOutcome(ConditionContext context, AnnotatedTypeMetadata metadata) {
+            String loginType = context.getEnvironment().getProperty("bella.login.type");
+            boolean isOAuthEnabled = "client".equalsIgnoreCase(loginType);
+            if(isOAuthEnabled) {
+                return ConditionOutcome.match("Client is enabled");
+            } else {
+                return ConditionOutcome.noMatch("Client is not enabled");
+            }
+        }
+    }
+}

--- a/api/spi/src/main/java/com/ke/bella/openapi/login/oauth/OAuthLoginFilter.java
+++ b/api/spi/src/main/java/com/ke/bella/openapi/login/oauth/OAuthLoginFilter.java
@@ -83,7 +83,7 @@ public class OAuthLoginFilter implements Filter {
             providers.add(provider);
         }
 
-        BellaResponse<List<Map<String, Object>>> bellaResponse = new BellaResponse();
+        BellaResponse<List<Map<String, Object>>> bellaResponse = new BellaResponse<>();
         bellaResponse.setCode(200);
         bellaResponse.setData(providers);
         response.setContentType("application/json");


### PR DESCRIPTION
- client登录模式使用server返回的url进行跳转。只需要配置openapi-base，不再需要loginPageUrl
- 同时支持了client模式使用CAS登录服务
- 使用ClientLoginFilter处理client模式的重定向
- 升级sdk，使用cas模式的后端，需要在前端请求头中加入X-BELLA-CONSOLE，否则不会跳转登录