### PR TITLE
feat: implement Lark document parsing file cleanup and support comple…

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -17,7 +17,7 @@
 
   <groupId>top.bella</groupId>
   <artifactId>bella-openapi</artifactId>
-  <version>1.1.12</version>
+  <version>1.1.20</version>
   <name>bella-openapi</name>
   <description>Bella OpenAPI SDK</description>
   <url>https://github.com/LianjiaTech/bella-openapi</url>

--- a/api/sdk/pom.xml
+++ b/api/sdk/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>top.bella</groupId>
         <artifactId>bella-openapi</artifactId>
-        <version>1.1.12</version>
+        <version>1.1.20</version>
     </parent>
 
     <artifactId>openapi-sdk</artifactId>

--- a/api/sdk/src/main/java/com/ke/bella/openapi/protocol/document/parse/DocParseResult.java
+++ b/api/sdk/src/main/java/com/ke/bella/openapi/protocol/document/parse/DocParseResult.java
@@ -141,7 +141,7 @@ public class DocParseResult {
     @Data
     public static class Cell {
         /**
-         * 单元格路径
+         * 单元格路径，单元格的path只在表格内部相对编号
          */
         private Object path;
         
@@ -149,5 +149,10 @@ public class DocParseResult {
          * 文本内容
          */
         private String text;
+
+        /**
+         * 单元格式复杂元素时使用，node内的path从头开始编号
+         */
+        private List<DocParseResult> nodes;
     }
 }

--- a/api/server/pom.xml
+++ b/api/server/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>top.bella</groupId>
         <artifactId>bella-openapi</artifactId>
-        <version>1.1.12</version>
+        <version>1.1.20</version>
     </parent>
     <artifactId>openapi-server</artifactId>
     <name>bella-openapi-server</name>

--- a/api/server/src/main/java/com/ke/bella/openapi/protocol/document/parse/LarkAdaptor.java
+++ b/api/server/src/main/java/com/ke/bella/openapi/protocol/document/parse/LarkAdaptor.java
@@ -6,7 +6,6 @@ import com.ke.bella.openapi.EndpointContext;
 import com.ke.bella.openapi.common.exception.BizParamCheckException;
 import com.ke.bella.openapi.common.exception.ChannelException;
 import com.ke.bella.openapi.utils.FileUtils;
-import com.ke.bella.openapi.utils.JacksonUtils;
 import com.lark.oapi.Client;
 import com.lark.oapi.service.docx.v1.model.Block;
 import com.lark.oapi.service.docx.v1.model.Image;
@@ -15,32 +14,22 @@ import com.lark.oapi.service.docx.v1.model.ListDocumentBlockResp;
 import com.lark.oapi.service.docx.v1.model.ListDocumentBlockRespBody;
 import com.lark.oapi.service.docx.v1.model.TableMergeInfo;
 import com.lark.oapi.service.docx.v1.model.TextElement;
-import com.lark.oapi.service.drive.v1.model.CreateImportTaskReq;
-import com.lark.oapi.service.drive.v1.model.CreateImportTaskResp;
-import com.lark.oapi.service.drive.v1.model.DownloadMediaReq;
-import com.lark.oapi.service.drive.v1.model.DownloadMediaResp;
-import com.lark.oapi.service.drive.v1.model.GetImportTaskReq;
-import com.lark.oapi.service.drive.v1.model.GetImportTaskResp;
-import com.lark.oapi.service.drive.v1.model.ImportTask;
-import com.lark.oapi.service.drive.v1.model.ImportTaskMountPoint;
-import com.lark.oapi.service.drive.v1.model.UploadAllFileReq;
-import com.lark.oapi.service.drive.v1.model.UploadAllFileReqBody;
-import com.lark.oapi.service.drive.v1.model.UploadAllFileResp;
 import lombok.extern.slf4j.Slf4j;
-import okhttp3.MediaType;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import java.io.ByteArrayOutputStream;
 import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Base64;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
+
+import static com.ke.bella.openapi.protocol.document.parse.LarkClientUtils.getImageUrl;
+import static com.ke.bella.openapi.protocol.document.parse.LarkClientUtils.importTask;
+import static com.ke.bella.openapi.protocol.document.parse.LarkClientUtils.queryTaskResult;
+import static com.ke.bella.openapi.protocol.document.parse.LarkClientUtils.uploadFile;
 
 @Slf4j
 @Component("LarkDocumentParse")
@@ -48,6 +37,9 @@ public class LarkAdaptor implements DocParseAdaptor<LarkProperty> {
 
     @Autowired
     private FileApiProperties fileApiProperties;
+
+    @Autowired
+    private LarkFileCleanupService cleanupService;
 
     @Override
     public DocParseTaskInfo parse(DocParseRequest request, String url, String channelCode, LarkProperty property) {
@@ -63,6 +55,10 @@ public class LarkAdaptor implements DocParseAdaptor<LarkProperty> {
             Client client = LarkClientProvider.client(property.getClientId(), property.getClientSecret());
             String fileToken = uploadFile(client, sourceFile.getName(), property.getUploadDirToken(), tempFile);
             String ticket = importTask(client, fileToken, property.getCloudDirToken(), sourceFile.getName(), fileType);
+            
+            // 注册文件清理任务
+            cleanupService.addCleanupTask(fileToken, ticket, property);
+            
             return DocParseTaskInfo.builder()
                     .taskId(TaskIdUtils.buildTaskId(channelCode, ticket))
                     .build();
@@ -74,7 +70,7 @@ public class LarkAdaptor implements DocParseAdaptor<LarkProperty> {
     @Override
     public DocParseResponse queryResult(String taskId, String url, LarkProperty property) {
         Client client = LarkClientProvider.client(property.getClientId(), property.getClientSecret());
-        DocParseResponse response = queryResult(client, taskId);
+        DocParseResponse response = queryTaskResult(client, taskId);
         if("success".equals(response.getStatus())) {
             DocParseResult result = getDocParseResult(client, response.getToken());
             response.setResult(result);
@@ -90,79 +86,6 @@ public class LarkAdaptor implements DocParseAdaptor<LarkProperty> {
     @Override
     public Class<?> getPropertyClass() {
         return LarkProperty.class;
-    }
-
-    private static String uploadFile(Client client, String fileName, String dirToken, File file) {
-        try {
-            UploadAllFileReq req = UploadAllFileReq.newBuilder()
-                    .uploadAllFileReqBody(UploadAllFileReqBody.newBuilder()
-                            .fileName(fileName)
-                            .file(file)
-                            .parentType("explorer")
-                            .parentNode(dirToken)
-                            .size((int) file.length())
-                            .build())
-                    .build();
-            UploadAllFileResp resp = client.drive().v1().file().uploadAll(req);
-            if(resp.getCode() != 0) {
-                throw ChannelException.fromResponse(502, resp.getMsg());
-            }
-            return resp.getData().getFileToken();
-        } catch (Exception e) {
-            throw ChannelException.fromException(e);
-        }
-    }
-
-    private static String importTask(Client client, String fileToken, String dirToken, String fileName, String fileType) {
-        CreateImportTaskReq req = CreateImportTaskReq.newBuilder()
-                .importTask(ImportTask.newBuilder()
-                        .fileExtension(fileType)
-                        .fileToken(fileToken)
-                        .type(fileType)
-                        .fileName(fileName)
-                        .point(ImportTaskMountPoint.newBuilder()
-                                .mountType(1)
-                                .mountKey(dirToken)
-                                .build())
-                        .build())
-                .build();
-        try {
-            CreateImportTaskResp resp = client.drive().v1().importTask().create(req);
-            if(resp.getCode() != 0) {
-                throw ChannelException.fromResponse(502, resp.getMsg());
-            }
-            return resp.getData().getTicket();
-        } catch (Exception e) {
-            throw ChannelException.fromException(e);
-        }
-    }
-
-    private static DocParseResponse queryResult(Client client, String ticket) {
-        GetImportTaskReq req = GetImportTaskReq.newBuilder()
-                .ticket(ticket)
-                .build();
-        try {
-            GetImportTaskResp resp = client.drive().v1().importTask().get(req);
-            if(resp.getCode() != 0){
-                throw ChannelException.fromResponse(502, resp.getMsg());
-            }
-            DocParseResponse response = new DocParseResponse();
-            switch (resp.getData().getResult().getJobStatus()) {
-                case 0:
-                    response.setToken(resp.getData().getResult().getToken());
-                    response.setStatus("success");
-                    break;
-                case 3:
-                    response.setStatus("failed");
-                    response.setMessage(resp.getData().getResult().getJobErrorMsg());
-                    break;
-                default:
-                    response.setStatus("processing");
-            }
-            return response;
-        } catch (Exception e) {
-            throw ChannelException.fromException(e);
-        }
     }
 
     private static DocParseResult getDocParseResult(Client client, String token) {
@@ -243,7 +166,7 @@ public class LarkAdaptor implements DocParseAdaptor<LarkProperty> {
         if (blocks == null || blocks.isEmpty()) {
             return null;
         }
-        
+
         // 找到根节点（parent_id为空的节点）
         Block rootBlock = blocks.stream()
                 .filter(block -> block.getParentId() == null || block.getParentId().isEmpty())
@@ -251,23 +174,23 @@ public class LarkAdaptor implements DocParseAdaptor<LarkProperty> {
                 .orElse(blocks.get(0));
 
         DocParseResult result = new DocParseResult();
-        
+
         // 设置根节点信息
         result.setSummary("");
         result.setPath(null); // 根节点path为null
         result.setElement(null); // 根节点element为null
-        
+
         // 获取所有属于根节点的直接子节点
         List<Block> rootChildren = blocks.stream()
                 .filter(block -> rootBlock.getBlockId().equals(block.getParentId()))
                 .collect(ArrayList::new, ArrayList::add, ArrayList::addAll);
-        
+
         // 按标题层级构建树形结构
         result.setChildren(buildHierarchicalStructure(rootChildren, blocks, client));
-        
+
         return result;
     }
-    
+
     /**
      * 按标题层级构建树形结构
      * @param blocks 要处理的Block列表
@@ -277,40 +200,40 @@ public class LarkAdaptor implements DocParseAdaptor<LarkProperty> {
      */
     private static List<DocParseResult> buildHierarchicalStructure(List<Block> blocks, List<Block> allBlocks, Client client) {
         List<DocParseResult> results = new ArrayList<>();
-        
+
         for (int i = 0; i < blocks.size(); i++) {
             Block currentBlock = blocks.get(i);
             int currentLevel = getHeadingLevel(currentBlock);
-            
+
             // 创建当前节点
             DocParseResult current = new DocParseResult();
             current.setSummary("");
             current.setPath(Arrays.asList(results.size() + 1)); // 路径从1开始
             current.setElement(createElement(currentBlock, allBlocks, client));
-            
+
             // 如果是标题，查找属于该标题的内容
             if (currentLevel > 0) {
                 List<Block> childBlocks = new ArrayList<>();
-                
+
                 // 找到下一个同级或更高级标题之前的所有内容
                 for (int j = i + 1; j < blocks.size(); j++) {
                     Block nextBlock = blocks.get(j);
                     int nextLevel = getHeadingLevel(nextBlock);
-                    
+
                     // 如果遇到同级或更高级标题，停止
                     if (nextLevel > 0 && nextLevel <= currentLevel) {
                         break;
                     }
-                    
+
                     childBlocks.add(nextBlock);
                 }
-                
+
                 // 递归构建子结构
                 current.setChildren(buildHierarchicalStructure(childBlocks, allBlocks, client));
-                
+
                 // 更新路径
                 updateChildrenPaths(current.getChildren(), current.getPath());
-                
+
                 // 跳过已处理的子节点
                 i += childBlocks.size();
             } else {
@@ -320,19 +243,19 @@ public class LarkAdaptor implements DocParseAdaptor<LarkProperty> {
                         .filter(block -> currentBlock.getBlockId().equals(block.getParentId()))
                         .filter(block -> !isTableRelatedBlock(block)) // 排除表格相关block
                         .collect(ArrayList::new, ArrayList::add, ArrayList::addAll);
-                
+
                 if (!directChildren.isEmpty()) {
                     current.setChildren(buildHierarchicalStructure(directChildren, allBlocks, client));
                     updateChildrenPaths(current.getChildren(), current.getPath());
                 }
             }
-            
+
             results.add(current);
         }
-        
+
         return results;
     }
-    
+
     /**
      * 判断是否为表格相关的block类型
      * @param block Block对象
@@ -342,7 +265,32 @@ public class LarkAdaptor implements DocParseAdaptor<LarkProperty> {
         if (block == null) return false;
         return 32 == block.getBlockType();
     }
-    
+
+    /**
+     * 判断Block是否包含复杂内容（非纯文本）
+     * @param block Block对象
+     * @return 是否为复杂内容
+     */
+    private static boolean isComplexBlock(Block block) {
+        if (block == null) return false;
+        
+        switch (block.getBlockType()) {
+        case 2: // text - 纯文本，不是复杂内容
+            return false;
+        case 27: // image - 图片是复杂内容
+        case 23: // equation - 公式是复杂内容
+        case 15: // code - 代码块是复杂内容
+        case 31: // table - 嵌套表格是复杂内容
+        case 12: // bullet - 列表项是复杂内容
+        case 13: // ordered - 有序列表项是复杂内容
+            return true;
+        case 3: case 4: case 5: case 6: case 7: case 8: case 9: case 10: case 11: // 各级标题
+            return true; // 标题在单元格中也算复杂内容
+        default:
+            return false;
+        }
+    }
+
     /**
      * 获取标题级别
      * @param block Block对象
@@ -350,21 +298,21 @@ public class LarkAdaptor implements DocParseAdaptor<LarkProperty> {
      */
     private static int getHeadingLevel(Block block) {
         if (block == null) return 0;
-        
+
         switch (block.getBlockType()) {
-            case 3: return 1; // heading1
-            case 4: return 2; // heading2
-            case 5: return 3; // heading3
-            case 6: return 4; // heading4
-            case 7: return 5; // heading5
-            case 8: return 6; // heading6
-            case 9: return 7; // heading7
-            case 10: return 8; // heading8
-            case 11: return 9; // heading9
-            default: return 0; // 非标题
+        case 3: return 1; // heading1
+        case 4: return 2; // heading2
+        case 5: return 3; // heading3
+        case 6: return 4; // heading4
+        case 7: return 5; // heading5
+        case 8: return 6; // heading6
+        case 9: return 7; // heading7
+        case 10: return 8; // heading8
+        case 11: return 9; // heading9
+        default: return 0; // 非标题
         }
     }
-    
+
     /**
      * 更新子节点的路径
      * @param children 子节点列表
@@ -372,7 +320,7 @@ public class LarkAdaptor implements DocParseAdaptor<LarkProperty> {
      */
     private static void updateChildrenPaths(List<DocParseResult> children, List<Integer> parentPath) {
         if (children == null || children.isEmpty()) return;
-        
+
         for (int i = 0; i < children.size(); i++) {
             DocParseResult child = children.get(i);
             List<Integer> childPath = new ArrayList<>();
@@ -381,12 +329,12 @@ public class LarkAdaptor implements DocParseAdaptor<LarkProperty> {
             }
             childPath.add(i + 1); // 路径从1开始
             child.setPath(childPath);
-            
+
             // 递归更新孙子节点
             updateChildrenPaths(child.getChildren(), childPath);
         }
     }
-    
+
     /**
      * 根据Block创建Element对象
      * @param block 飞书Block对象
@@ -396,124 +344,124 @@ public class LarkAdaptor implements DocParseAdaptor<LarkProperty> {
      */
     private static DocParseResult.Element createElement(Block block, List<Block> allBlocks, Client client) {
         DocParseResult.Element element = new DocParseResult.Element();
-        
+
         // 根据block_type设置类型和内容
         switch (block.getBlockType()) {
-            case 1: // page
-                element.setType("Text");
-                if (block.getPage() != null) {
-                    element.setText(extractElementsText(block.getPage().getElements()));
-                }
-                break;
-            case 2: // text
-                element.setType("Text");
-                if (block.getText() != null) {
-                    element.setText(extractElementsText(block.getText().getElements()));
-                }
-                break;
-            case 3: // heading1
-                element.setType("Title");
-                if (block.getHeading1() != null) {
-                    element.setText(extractElementsText(block.getHeading1().getElements()));
-                }
-                break;
-            case 4: // heading2
-                element.setType("Title");
-                if (block.getHeading2() != null) {
-                    element.setText(extractElementsText(block.getHeading2().getElements()));
-                }
-                break;
-            case 5: // heading3
-                element.setType("Title");
-                if (block.getHeading3() != null) {
-                    element.setText(extractElementsText(block.getHeading3().getElements()));
-                }
-                break;
-            case 6: // heading4
-                element.setType("Title");
-                if (block.getHeading4() != null) {
-                    element.setText(extractElementsText(block.getHeading4().getElements()));
-                }
-                break;
-            case 7: // heading5
-                element.setType("Title");
-                if (block.getHeading5() != null) {
-                    element.setText(extractElementsText(block.getHeading5().getElements()));
-                }
-                break;
-            case 8: // heading6
-                element.setType("Title");
-                if (block.getHeading6() != null) {
-                    element.setText(extractElementsText(block.getHeading6().getElements()));
-                }
-                break;
-            case 9: // heading7
-                element.setType("Title");
-                if (block.getHeading7() != null) {
-                    element.setText(extractElementsText(block.getHeading7().getElements()));
-                }
-                break;
-            case 10: // heading8
-                element.setType("Title");
-                if (block.getHeading8() != null) {
-                    element.setText(extractElementsText(block.getHeading8().getElements()));
-                }
-                break;
-            case 11: // heading9
-                element.setType("Title");
-                if (block.getHeading9() != null) {
-                    element.setText(extractElementsText(block.getHeading9().getElements()));
-                }
-                break;
-            case 12: // bullet
-                element.setType("ListItem");
-                if (block.getBullet() != null) {
-                    element.setText(extractElementsText(block.getBullet().getElements()));
-                }
-                break;
-            case 13: // ordered
-                element.setType("ListItem");
-                if (block.getOrdered() != null) {
-                    element.setText(extractElementsText(block.getOrdered().getElements()));
-                }
-                break;
-            case 15: // code
-                element.setType("Code");
-                if (block.getCode() != null) {
-                    element.setText(extractElementsText(block.getCode().getElements()));
-                }
-                break;
-            case 23: // equation
-                element.setType("Formula");
-                if (block.getEquation() != null) {
-                    element.setText(extractElementsText(block.getEquation().getElements()));
-                }
-                break;
-            case 31: // table
-                element.setType("Table");
-                if (block.getTable() != null) {
-                    element.setRows(convertTableRows(block, allBlocks));
-                }
-                break;
-            case 27: // image
-                element.setType("Figure");
-                if (block.getImage() != null) {
-                    DocParseResult.Image image = convertImage(block.getImage(), client);
-                    element.setImage(image);
-                }
-                break;
-            case 32: // table_cell
-                element.setType("Text"); // 表格单元格作为文本处理
-                // 表格单元格的内容通过children处理
-                break;
-            default:
-                element.setType("Text");
-                element.setText("");
+        case 1: // page
+            element.setType("Text");
+            if (block.getPage() != null) {
+                element.setText(extractElementsText(block.getPage().getElements()));
+            }
+            break;
+        case 2: // text
+            element.setType("Text");
+            if (block.getText() != null) {
+                element.setText(extractElementsText(block.getText().getElements()));
+            }
+            break;
+        case 3: // heading1
+            element.setType("Title");
+            if (block.getHeading1() != null) {
+                element.setText(extractElementsText(block.getHeading1().getElements()));
+            }
+            break;
+        case 4: // heading2
+            element.setType("Title");
+            if (block.getHeading2() != null) {
+                element.setText(extractElementsText(block.getHeading2().getElements()));
+            }
+            break;
+        case 5: // heading3
+            element.setType("Title");
+            if (block.getHeading3() != null) {
+                element.setText(extractElementsText(block.getHeading3().getElements()));
+            }
+            break;
+        case 6: // heading4
+            element.setType("Title");
+            if (block.getHeading4() != null) {
+                element.setText(extractElementsText(block.getHeading4().getElements()));
+            }
+            break;
+        case 7: // heading5
+            element.setType("Title");
+            if (block.getHeading5() != null) {
+                element.setText(extractElementsText(block.getHeading5().getElements()));
+            }
+            break;
+        case 8: // heading6
+            element.setType("Title");
+            if (block.getHeading6() != null) {
+                element.setText(extractElementsText(block.getHeading6().getElements()));
+            }
+            break;
+        case 9: // heading7
+            element.setType("Title");
+            if (block.getHeading7() != null) {
+                element.setText(extractElementsText(block.getHeading7().getElements()));
+            }
+            break;
+        case 10: // heading8
+            element.setType("Title");
+            if (block.getHeading8() != null) {
+                element.setText(extractElementsText(block.getHeading8().getElements()));
+            }
+            break;
+        case 11: // heading9
+            element.setType("Title");
+            if (block.getHeading9() != null) {
+                element.setText(extractElementsText(block.getHeading9().getElements()));
+            }
+            break;
+        case 12: // bullet
+            element.setType("ListItem");
+            if (block.getBullet() != null) {
+                element.setText(extractElementsText(block.getBullet().getElements()));
+            }
+            break;
+        case 13: // ordered
+            element.setType("ListItem");
+            if (block.getOrdered() != null) {
+                element.setText(extractElementsText(block.getOrdered().getElements()));
+            }
+            break;
+        case 15: // code
+            element.setType("Code");
+            if (block.getCode() != null) {
+                element.setText(extractElementsText(block.getCode().getElements()));
+            }
+            break;
+        case 23: // equation
+            element.setType("Formula");
+            if (block.getEquation() != null) {
+                element.setText(extractElementsText(block.getEquation().getElements()));
+            }
+            break;
+        case 31: // table
+            element.setType("Table");
+            if (block.getTable() != null) {
+                element.setRows(convertTableRows(block, allBlocks, client));
+            }
+            break;
+        case 27: // image
+            element.setType("Figure");
+            if (block.getImage() != null) {
+                DocParseResult.Image image = convertImage(block.getImage(), client);
+                element.setImage(image);
+            }
+            break;
+        case 32: // table_cell
+            element.setType("Text"); // 表格单元格作为文本处理
+            // 表格单元格的内容通过children处理
+            break;
+        default:
+            element.setType("Text");
+            element.setText("");
         }
-        
+
         return element;
     }
-    
+
     /**
      * 从elements数组中提取文本内容
      * @param elements 文本元素数组
@@ -523,9 +471,9 @@ public class LarkAdaptor implements DocParseAdaptor<LarkProperty> {
         if (elements == null || elements.length == 0) {
             return "";
         }
-        
+
         StringBuilder text = new StringBuilder();
-        
+
         for (TextElement element : elements) {
             if (element != null) {
                 String content = extractTextFromElement(element);
@@ -534,10 +482,10 @@ public class LarkAdaptor implements DocParseAdaptor<LarkProperty> {
                 }
             }
         }
-        
+
         return text.toString();
     }
-    
+
     /**
      * 从单个TextElement中提取文本内容
      * @param element TextElement对象
@@ -547,7 +495,7 @@ public class LarkAdaptor implements DocParseAdaptor<LarkProperty> {
         if (element == null) {
             return "";
         }
-        
+
         // 根据TextElement的不同类型提取文本
         if (element.getTextRun() != null && element.getTextRun().getContent() != null) {
             // 普通文本
@@ -570,65 +518,66 @@ public class LarkAdaptor implements DocParseAdaptor<LarkProperty> {
         }
         return "";
     }
-    
+
     /**
      * 转换表格行数据
      * @param block 表格Block
      * @param allBlocks 所有Block列表
+     * @param client LarkClient
      * @return 行数据列表
      */
-    private static List<DocParseResult.Row> convertTableRows(Block block, List<Block> allBlocks) {
+    private static List<DocParseResult.Row> convertTableRows(Block block, List<Block> allBlocks, Client client) {
         List<DocParseResult.Row> rows = new ArrayList<>();
-        
-        if (block.getTable() == null || block.getTable().getCells() == null || 
-            block.getTable().getProperty() == null) {
+
+        if (block.getTable() == null || block.getTable().getCells() == null ||
+                block.getTable().getProperty() == null) {
             return rows;
         }
-        
+
         try {
             // 获取表格属性
             Integer columnSize = block.getTable().getProperty().getColumnSize();
             Integer rowSize = block.getTable().getProperty().getRowSize();
             String[] cellIds = block.getTable().getCells();
-            
+
             if (columnSize == null || rowSize == null || cellIds == null) {
                 return rows;
             }
 
             int[][] position = new int[rowSize][columnSize];
-            
+
             // 构建cellId到Block的映射
-            java.util.Map<String, Block> cellBlockMap = allBlocks.stream()
+            Map<String, Block> cellBlockMap = allBlocks.stream()
                     .filter(b -> b.getTableCell() != null)
-                    .collect(java.util.stream.Collectors.toMap(
-                            Block::getBlockId, 
+                    .collect(Collectors.toMap(
+                            Block::getBlockId,
                             java.util.function.Function.identity(),
                             (existing, replacement) -> existing
                     ));
-            
+
             // 按行构建表格
             for (int row = 0; row < rowSize; row++) {
                 DocParseResult.Row rowData = new DocParseResult.Row();
                 List<DocParseResult.Cell> cells = new ArrayList<>();
                 boolean hasValidCells = false;
-                
+
                 // 按列构建单元格
                 for (int col = 0; col < columnSize; col++) {
-                    
+
                     int cellIndex = row * columnSize + col;
                     if (cellIndex < cellIds.length) {
                         String cellId = cellIds[cellIndex];
                         Block cellBlock = cellBlockMap.get(cellId);
-                        
+
                         DocParseResult.Cell cell = new DocParseResult.Cell();
-                        
+
                         // 计算单元格的合并信息
                         int rowSpan = 1;
                         int colSpan = 1;
-                        
+
                         // 从表格的merge_info中获取合并信息
-                        if (block.getTable().getProperty().getMergeInfo() != null && 
-                            cellIndex < block.getTable().getProperty().getMergeInfo().length) {
+                        if (block.getTable().getProperty().getMergeInfo() != null &&
+                                cellIndex < block.getTable().getProperty().getMergeInfo().length) {
                             TableMergeInfo mergeInfo = block.getTable().getProperty().getMergeInfo()[cellIndex];
                             if (mergeInfo != null) {
                                 rowSpan = mergeInfo.getRowSpan();
@@ -646,38 +595,60 @@ public class LarkAdaptor implements DocParseAdaptor<LarkProperty> {
 
                         List<Integer> cellCoords = Arrays.asList(startRow, endRow, startCol, endCol);
                         cell.setPath(cellCoords);
-                        
-                        String cellText = "";
+
+                        // 处理复杂单元格：如果不是纯文本，解析为node
                         if (cellBlock != null && cellBlock.getChildren() != null) {
-                            // 提取单元格内容（通常是子文本块）
-                            StringBuilder cellContent = new StringBuilder();
+                            List<Block> childBlocks = new ArrayList<>();
+                            boolean hasComplexContent = false;
+                            
+                            // 收集所有子块并检查是否包含复杂内容
                             for (String childId : cellBlock.getChildren()) {
                                 Block childBlock = allBlocks.stream()
                                         .filter(b -> childId.equals(b.getBlockId()))
                                         .findFirst()
                                         .orElse(null);
                                 
-                                if (childBlock != null && childBlock.getText() != null) {
-                                    String childText = extractElementsText(childBlock.getText().getElements());
-                                    if (!childText.isEmpty()) {
-                                        if (cellContent.length() > 0) {
-                                            cellContent.append("\n");
-                                        }
-                                        cellContent.append(childText);
+                                if (childBlock != null) {
+                                    childBlocks.add(childBlock);
+                                    // 检查是否为复杂内容（非纯文本）
+                                    if (isComplexBlock(childBlock)) {
+                                        hasComplexContent = true;
                                     }
                                 }
                             }
-                            cellText = cellContent.toString();
+                            
+                            if (hasComplexContent) {
+                                // 包含复杂内容，转换为节点结构
+                                List<DocParseResult> cellNodes = buildHierarchicalStructure(childBlocks, allBlocks, client);
+                                cell.setNodes(cellNodes);
+                                cell.setText(""); // 复杂单元格不设置文本
+                            } else {
+                                // 纯文本内容，提取文本
+                                StringBuilder cellContent = new StringBuilder();
+                                for (Block childBlock : childBlocks) {
+                                    if (childBlock.getText() != null) {
+                                        String childText = extractElementsText(childBlock.getText().getElements());
+                                        if (!childText.isEmpty()) {
+                                            if (cellContent.length() > 0) {
+                                                cellContent.append("\n");
+                                            }
+                                            cellContent.append(childText);
+                                        }
+                                    }
+                                }
+                                cell.setText(cellContent.toString());
+                            }
+                        } else {
+                            cell.setText("");
                         }
-                        cell.setText(cellText);
-                        
+
                         // 如果单元格有内容，标记该行有有效单元格
-                        if (StringUtils.isNotBlank(cellText)) {
+                        if (StringUtils.isNotBlank(cell.getText()) || (cell.getNodes() != null && !cell.getNodes().isEmpty())) {
                             hasValidCells = true;
                         } else if (position[row][col] == 1) {
                             continue; // 如果当前单元格内容为空，且已经被占用则跳过
                         }
-                        
+
                         cells.add(cell);
 
                         // 标记当前单元格占用的所有位置
@@ -688,7 +659,7 @@ public class LarkAdaptor implements DocParseAdaptor<LarkProperty> {
                         }
                     }
                 }
-                
+
                 if (hasValidCells) {
                     rowData.setCells(cells);
                     rows.add(rowData);
@@ -698,10 +669,10 @@ public class LarkAdaptor implements DocParseAdaptor<LarkProperty> {
             // 如果转换失败，返回空列表
             LOGGER.warn("转换表格时出错: " + e.getMessage(), e);
         }
-        
+
         return rows;
     }
-    
+
     /**
      * 转换图片信息
      * @param imageBlock 图片Block对象
@@ -712,33 +683,8 @@ public class LarkAdaptor implements DocParseAdaptor<LarkProperty> {
         DocParseResult.Image image = new DocParseResult.Image();
         image.setType("image_base64");
         image.setBase64(getImageUrl(imageBlock, client));
-        
+
         return image;
     }
-    
-    /**
-     * 获取图片
-     * @param imageBlock 图片Block对象
-     * @param client LarkClient
-     * @return 图片Base64String
-     */
-    private static String getImageUrl(Image imageBlock, Client client) {
-        DownloadMediaReq req = DownloadMediaReq.newBuilder()
-                .fileToken(imageBlock.getToken())
-                .build();
-        try {
-            DownloadMediaResp resp = client.drive().v1().media().download(req);
-            if(resp.getCode() != 0) {
-                LOGGER.warn(resp.getMsg());
-                return "";
-            }
-            ByteArrayOutputStream stream = resp.getData();
-            String fileName = resp.getFileName();
-            MediaType mimeType = FileUtils.extraMediaType(fileName);
-            return "data:" + mimeType + ";base64," + Base64.getEncoder().encodeToString(stream.toByteArray());
-        } catch (Exception e) {
-            LOGGER.warn(e.getMessage(), e);
-            return "";
-        }
-    }
+
 }

--- a/api/server/src/main/java/com/ke/bella/openapi/protocol/document/parse/LarkClientUtils.java
+++ b/api/server/src/main/java/com/ke/bella/openapi/protocol/document/parse/LarkClientUtils.java
@@ -1,0 +1,155 @@
+package com.ke.bella.openapi.protocol.document.parse;
+
+import com.ke.bella.openapi.common.exception.ChannelException;
+import com.ke.bella.openapi.utils.FileUtils;
+import com.lark.oapi.Client;
+import com.lark.oapi.service.docx.v1.model.Image;
+import com.lark.oapi.service.drive.v1.model.CreateImportTaskReq;
+import com.lark.oapi.service.drive.v1.model.CreateImportTaskResp;
+import com.lark.oapi.service.drive.v1.model.DeleteFileReq;
+import com.lark.oapi.service.drive.v1.model.DeleteFileResp;
+import com.lark.oapi.service.drive.v1.model.DownloadMediaReq;
+import com.lark.oapi.service.drive.v1.model.DownloadMediaResp;
+import com.lark.oapi.service.drive.v1.model.GetImportTaskReq;
+import com.lark.oapi.service.drive.v1.model.GetImportTaskResp;
+import com.lark.oapi.service.drive.v1.model.ImportTask;
+import com.lark.oapi.service.drive.v1.model.ImportTaskMountPoint;
+import com.lark.oapi.service.drive.v1.model.UploadAllFileReq;
+import com.lark.oapi.service.drive.v1.model.UploadAllFileReqBody;
+import com.lark.oapi.service.drive.v1.model.UploadAllFileResp;
+import lombok.extern.slf4j.Slf4j;
+import okhttp3.MediaType;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.util.Base64;
+
+@Slf4j
+public class LarkClientUtils {
+
+    public static String uploadFile(Client client, String fileName, String dirToken, File file) {
+        try {
+            UploadAllFileReq req = UploadAllFileReq.newBuilder()
+                    .uploadAllFileReqBody(UploadAllFileReqBody.newBuilder()
+                            .fileName(fileName)
+                            .file(file)
+                            .parentType("explorer")
+                            .parentNode(dirToken)
+                            .size((int) file.length())
+                            .build())
+                    .build();
+            UploadAllFileResp resp = client.drive().v1().file().uploadAll(req);
+            if(resp.getCode() != 0) {
+                throw ChannelException.fromResponse(502, resp.getMsg());
+            }
+            return resp.getData().getFileToken();
+        } catch (Exception e) {
+            throw ChannelException.fromException(e);
+        }
+    }
+
+    public static String importTask(Client client, String fileToken, String dirToken, String fileName, String fileType) {
+        CreateImportTaskReq req = CreateImportTaskReq.newBuilder()
+                .importTask(ImportTask.newBuilder()
+                        .fileExtension(fileType)
+                        .fileToken(fileToken)
+                        .type(fileType)
+                        .fileName(fileName)
+                        .point(ImportTaskMountPoint.newBuilder()
+                                .mountType(1)
+                                .mountKey(dirToken)
+                                .build())
+                        .build())
+                .build();
+        try {
+            CreateImportTaskResp resp = client.drive().v1().importTask().create(req);
+            if(resp.getCode() != 0) {
+                throw ChannelException.fromResponse(502, resp.getMsg());
+            }
+            return resp.getData().getTicket();
+        } catch (Exception e) {
+            throw ChannelException.fromException(e);
+        }
+    }
+
+    public static DocParseResponse queryTaskResult(Client client, String ticket) {
+        GetImportTaskReq req = GetImportTaskReq.newBuilder()
+                .ticket(ticket)
+                .build();
+        try {
+            GetImportTaskResp resp = client.drive().v1().importTask().get(req);
+            if(resp.getCode() != 0){
+                throw ChannelException.fromResponse(502, resp.getMsg());
+            }
+            DocParseResponse response = new DocParseResponse();
+            switch (resp.getData().getResult().getJobStatus()) {
+            case 0:
+                response.setToken(resp.getData().getResult().getToken());
+                response.setStatus("success");
+                break;
+            case 3:
+                response.setStatus("failed");
+                response.setMessage(resp.getData().getResult().getJobErrorMsg());
+                break;
+            default:
+                response.setStatus("processing");
+            }
+            return response;
+        } catch (Exception e) {
+            throw ChannelException.fromException(e);
+        }
+    }
+
+    /**
+     * 删除文件
+     * @param client Lark客户端
+     * @param fileToken 文件token
+     * @param fileType 文件类型
+     * @return 删除是否成功
+     */
+    public static boolean deleteFile(Client client, String fileToken, String fileType) {
+        try {
+            DeleteFileReq req = DeleteFileReq.newBuilder()
+                    .fileToken(fileToken)
+                    .type(fileType)
+                    .build();
+
+            DeleteFileResp resp = client.drive().v1().file().delete(req);
+            if (resp.getCode() != 0) {
+                LOGGER.error("Failed to delete file {}: {}", fileToken, resp.getMsg());
+                return false;
+            }
+            LOGGER.info("Successfully deleted file: {}", fileToken);
+            return true;
+        } catch (Exception e) {
+            LOGGER.error("Exception when deleting file {}: {}", fileToken, e.getMessage(), e);
+            return false;
+        }
+    }
+
+    /**
+     * 获取图片
+     * @param imageBlock 图片Block对象
+     * @param client LarkClient
+     * @return 图片Base64String
+     */
+    public static String getImageUrl(Image imageBlock, Client client) {
+        DownloadMediaReq req = DownloadMediaReq.newBuilder()
+                .fileToken(imageBlock.getToken())
+                .build();
+        try {
+            DownloadMediaResp resp = client.drive().v1().media().download(req);
+            if(resp.getCode() != 0) {
+                LOGGER.warn(resp.getMsg());
+                return "";
+            }
+            ByteArrayOutputStream stream = resp.getData();
+            String fileName = resp.getFileName();
+            MediaType mimeType = FileUtils.extraMediaType(fileName);
+            return "data:" + mimeType + ";base64," + Base64.getEncoder().encodeToString(stream.toByteArray());
+        } catch (Exception e) {
+            LOGGER.warn(e.getMessage(), e);
+            return "";
+        }
+    }
+}

--- a/api/server/src/main/java/com/ke/bella/openapi/protocol/document/parse/LarkFileCleanupService.java
+++ b/api/server/src/main/java/com/ke/bella/openapi/protocol/document/parse/LarkFileCleanupService.java
@@ -1,0 +1,148 @@
+package com.ke.bella.openapi.protocol.document.parse;
+
+import com.ke.bella.openapi.utils.JacksonUtils;
+import com.lark.oapi.Client;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.Objects;
+import org.redisson.api.RScoredSortedSet;
+import org.redisson.api.RedissonClient;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import static com.ke.bella.openapi.protocol.document.parse.LarkClientUtils.deleteFile;
+import static com.ke.bella.openapi.protocol.document.parse.LarkClientUtils.queryTaskResult;
+
+/**
+ * Lark文件清理服务
+ * 简单的定时任务，定期检查任务状态并清理已完成任务的文件
+ */
+@Slf4j
+@Service
+public class LarkFileCleanupService {
+
+    private static final String CLEANUP_ZSET_KEY = "lark:file:cleanup:zset";
+    
+    @Autowired
+    private RedissonClient redissonClient;
+
+    /**
+     * 添加清理任务
+     * @param fileToken 文件token
+     * @param ticket 任务ticket
+     * @param property Lark配置属性
+     */
+    public void addCleanupTask(String fileToken, String ticket, LarkProperty property) {
+        long executeTime = System.currentTimeMillis() + 30000;
+        CleanupTask task = new CleanupTask(fileToken, ticket, "file", property.getClientId(), property.getClientSecret(), executeTime);
+        String taskJson = JacksonUtils.serialize(task);
+
+        RScoredSortedSet<String> zset = redissonClient.getScoredSortedSet(CLEANUP_ZSET_KEY);
+        zset.add(executeTime, taskJson);
+
+        LOGGER.info("Added cleanup task for file: {}, ticket: {}", fileToken, ticket);
+    }
+
+    /**
+     * 定时清理任务，每分钟执行一次
+     */
+    @Scheduled(fixedRate = 10000) // 每10s执行一次
+    public void cleanupCompletedTasks() {
+        RScoredSortedSet<String> zset = redissonClient.getScoredSortedSet(CLEANUP_ZSET_KEY);
+        
+        long currentTime = System.currentTimeMillis();
+        
+        while (!zset.isEmpty()) {
+            // 原子操作取出并删除最小score的任务
+            String taskJson = zset.pollFirst();
+            if (taskJson == null) {
+                break; // 队列为空
+            }
+            
+            try {
+                CleanupTask task = JacksonUtils.deserialize(taskJson, CleanupTask.class);
+
+                if(task == null) {
+                    continue;
+                }
+
+                // 检查任务执行时间是否到了
+                if (task.getTimestamp() > currentTime) {
+                    // 任务还没到执行时间，重新放回去并退出
+                    zset.add(task.getTimestamp(), taskJson);
+                    break;
+                }
+                
+                // 使用ticket查询任务状态
+                Client client = LarkClientProvider.client(task.getClientId(), task.getClientSecret());
+                DocParseResponse response = queryTaskResult(client, task.getTicket());
+                
+                if ("success".equals(response.getStatus()) || "failed".equals(response.getStatus())) {
+                    // 任务已完成（成功或失败），删除文件
+                    boolean deleted = deleteFile(client, task.getFileToken(), task.getFileType());
+                    if (deleted) {
+                        // 任务已成功处理
+                        LOGGER.info("Successfully cleaned up file for completed task - fileToken: {}, ticket: {}",
+                                task.getFileToken(), task.getTicket());
+                    } else {
+                        // 删除文件失败，10s后重试
+                        task.setTimestamp(currentTime + 10000);
+                        String newTaskJson = JacksonUtils.serialize(task);
+                        zset.add(task.getTimestamp(), newTaskJson);
+                        LOGGER.warn("Failed to delete file for completed task, will retry in 10s - fileToken: {}, ticket: {}",
+                                task.getFileToken(), task.getTicket());
+                    }
+                } else {
+                    // 任务仍在处理中，10s后重新检查
+                    task.setTimestamp(currentTime + 10000);
+                    String newTaskJson = JacksonUtils.serialize(task);
+                    zset.add(task.getTimestamp(), newTaskJson);
+                    LOGGER.debug("Task still processing, will retry in 10s - fileToken: {}, ticket: {}",
+                            task.getFileToken(), task.getTicket());
+                }
+                
+            } catch (Exception e) {
+                // 查询失败，10s后重试
+                CleanupTask task = JacksonUtils.deserialize(taskJson, CleanupTask.class);
+                if(task != null) {
+                    task.setTimestamp(currentTime + 10000);
+                    String newTaskJson = JacksonUtils.serialize(task);
+                    zset.add(task.getTimestamp(), newTaskJson);
+                }
+                LOGGER.error("Failed to query task status for cleanup, will retry in 10s - error: {}", e.getMessage());
+            }
+        }
+    }
+
+    /**
+     * 清理任务数据结构
+     */
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    private static class CleanupTask {
+        private String fileToken;
+        private String ticket;
+        private String fileType;
+        private String clientId;
+        private String clientSecret;
+        private long timestamp;
+        
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) return true;
+            if (obj == null || getClass() != obj.getClass()) return false;
+            CleanupTask task = (CleanupTask) obj;
+            return Objects.equals(ticket, task.ticket);
+        }
+        
+        @Override
+        public int hashCode() {
+            return ticket != null ? ticket.hashCode() : 0;
+        }
+    }
+}

--- a/api/spi/pom.xml
+++ b/api/spi/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>top.bella</groupId>
         <artifactId>bella-openapi</artifactId>
-        <version>1.1.12</version>
+        <version>1.1.20</version>
     </parent>
     <artifactId>openapi-spi</artifactId>
     <packaging>jar</packaging>


### PR DESCRIPTION
- LarkFileCleanupService使用 redisList作为队列，是为了避免使用内存队列重启服务时导致未处理任务丢失，否则在重启时需要等待导入任务完成后进行删除，才能关闭服务。时间线长影响服务发布。
-  支持了复杂单元格（非纯文本类型）的解析
-  LarkClient相关的逻辑提取到工具类中，与协议相关的逻辑仍保留在Adaptor中

issues: #117