### PR TITLE
feat: cookie security across redirects

### DIFF
--- a/api/spi/src/main/java/com/ke/bella/openapi/login/session/RedisSessionManager.java
+++ b/api/spi/src/main/java/com/ke/bella/openapi/login/session/RedisSessionManager.java
@@ -151,7 +151,10 @@ public class RedisSessionManager implements SessionManager, TicketManager { // C
         if(request != null && response != null) {
             Cookie cookie = new Cookie(sessionProperty.getCookieName(), id);
             cookie.setMaxAge(sessionProperty.getCookieMaxAge());
-            cookie.setSecure(request.isSecure());
+
+            String redirectUrl = request.getParameter("redirect");
+            cookie.setSecure(!(StringUtils.isNotBlank(redirectUrl) && redirectUrl.startsWith("http://")));
+
             if(StringUtils.isBlank(sessionProperty.getCookieContextPath())) {
                 cookie.setPath("/");
             } else {


### PR DESCRIPTION
以源网站协议为准；http则不设置secure；否则无证书域名都无法使用此登录