### PR TITLE
fix: remove image placeholders to optimize display

### DIFF
--- a/web/src/app/playground/v1/chat/completions/page.tsx
+++ b/web/src/app/playground/v1/chat/completions/page.tsx
@@ -122,7 +122,7 @@ export default function ChatCompletions() {
       if (mimeType.startsWith('image/')) {
         images.push({ mimeType, base64Data });
         // 在文本中用占位符替换图像
-        textContent = textContent.replace(fullMatch, '[图像]');
+        textContent = textContent.replace(fullMatch, '');
       }
     }
     
@@ -147,7 +147,7 @@ export default function ChatCompletions() {
       if (mimeType.startsWith('image/')) {
         images.push({ mimeType, base64Data });
         // 在文本中用占位符替换图像
-        textContent = textContent.replace(fullMatch, '[图像]');
+        textContent = textContent.replace(fullMatch, '');
       }
     }
     


### PR DESCRIPTION
bug fix：
<img width="157" height="82" alt="企业微信截图_5390faa4-d3a3-4ac9-9b28-e9a1d0e74ead" src="https://github.com/user-attachments/assets/ef860c47-c3e6-4f87-84cf-29d234e29063" />
