### PR TITLE
fix: tencent-asr set vad param

### DIFF
--- a/api/server/src/main/java/com/ke/bella/openapi/protocol/asr/realtime/TencentAdaptor.java
+++ b/api/server/src/main/java/com/ke/bella/openapi/protocol/asr/realtime/TencentAdaptor.java
@@ -110,6 +110,7 @@ public class TencentAdaptor implements RealTimeAsrAdaptor<TencentProperty> {
 			params.put("nonce", String.valueOf(nonce));
 			params.put("engine_model_type", property.getEngineModelType());
 			params.put("voice_id", request.getVoiceId());
+			params.put("needvad", "1");
 
 			// 可选参数
 			if (request.getVoiceFormat() != null) {


### PR DESCRIPTION
fix: tencent-websocket-asr 开启握手阶段时强制开启 needvad 参数，校准 whisper 事件

在腾讯云实时语音识别协议中，slice_type 与 bella-openapi 的 asr 语句变化逻辑基本校准:
- slice_type = 0 <=> SentenceBegin
- slice_type = 1 <=> TranscriptionResultChanged
- slice_type = 2 <=> SentenceEnd (needvad 未开启时无法触发）

此前`默认不开启 needvad` 参数，在使用时无法接收到 SentenceEnd 事件，在多轮对话场景下会使文本消息积压。

for ex:
- `needvad = 0`
<img width="2094" height="1028" alt="image" src="https://github.com/user-attachments/assets/8ce0c107-b510-4113-b0a1-32fc37a119b6" />

- `needvad = 1`
<img width="2370" height="888" alt="image" src="https://github.com/user-attachments/assets/37a73d5b-60a7-4bea-b079-140357b43217" />

> 仅影响事件，不影响转录文本结果

## References:
- 「关键词：slice_type」https://cloud.tencent.com/document/product/1093/48982
- 「Bella-OpenAPI - asr/stream」 https://doc.bella.top/docs/bella-openapi/core/realtime