### PR TITLE
refactor: huoshan asr adaptor

### DIFF
--- a/api/server/src/main/java/com/ke/bella/openapi/protocol/asr/HuoshanRealTimeAsrRequest.java
+++ b/api/server/src/main/java/com/ke/bella/openapi/protocol/asr/HuoshanRealTimeAsrRequest.java
@@ -15,9 +15,12 @@ public class HuoshanRealTimeAsrRequest {
     private byte[] audioData;
     private int chunkSize;
     private int intervalMs;
-    private String resultType; //full single
-    private String hotWords; // 热词字符串
-    private String hotWordsTableId; // 热词表id
+    private String resultType; 			// full single
+    private String hotWords; 			// 热词字符串
+    private String hotWordsTableId; 	// 热词表id
+
+	private boolean enable_punc;		// 启用 标点预测
+	private boolean enable_itn;			// 启用 逆文本规范化
 
     public HuoshanRealTimeAsrRequest(AsrRequest request, HuoshanProperty property) {
         this.async = false;
@@ -48,5 +51,8 @@ public class HuoshanRealTimeAsrRequest {
         this.resultType = "single";
         this.hotWords = request.getPayload().getHotWords();
         this.hotWordsTableId = request.getPayload().getHotWordsTableId();
+
+		this.enable_punc = request.getPayload().getEnablePunctuationPrediction();
+		this.enable_itn = request.getPayload().getEnableInverseTextNormalization();
     }
 }

--- a/api/server/src/main/java/com/ke/bella/openapi/protocol/asr/HuoshanStreamAsrCallback.java
+++ b/api/server/src/main/java/com/ke/bella/openapi/protocol/asr/HuoshanStreamAsrCallback.java
@@ -67,6 +67,9 @@ public class HuoshanStreamAsrCallback implements Callbacks.WebSocketCallback {
         static final int CUSTOM_COMPRESS = 0b1111;
     }
 
+	// 默认自定义工作流
+	private static String DEFAULT_WORKFLOW = "audio_in,resample,partition,vad,fe,decode";
+
     private final HuoshanRealTimeAsrRequest request;
     private final Sender sender;
     private final EndpointProcessData processData;
@@ -237,7 +240,17 @@ public class HuoshanStreamAsrCallback implements Callbacks.WebSocketCallback {
         modelRequest.setShow_utterances(true);
         modelRequest.setResult_type(request.getResultType());
 		modelRequest.setSequence(1);
-		modelRequest.setWorkflow("audio_in,resample,partition,vad,fe,decode,nlu_punctuate"); // 启用标点符号
+
+		// 设置自定义工作流
+		StringBuilder workflowBuilder = new StringBuilder();
+		workflowBuilder.append(DEFAULT_WORKFLOW);
+		if (request.isEnable_itn()) {
+			workflowBuilder.append(",itn");
+		}
+		if (request.isEnable_punc()) {
+			workflowBuilder.append(",nlu_punctuate");
+		}
+		modelRequest.setWorkflow(workflowBuilder.toString());
         clientRequest.setRequest(modelRequest);
 
         // 设置音频信息

--- a/api/server/src/main/java/com/ke/bella/openapi/protocol/asr/HuoshanStreamLMAsrCallback.java
+++ b/api/server/src/main/java/com/ke/bella/openapi/protocol/asr/HuoshanStreamLMAsrCallback.java
@@ -261,9 +261,9 @@ public class HuoshanStreamLMAsrCallback extends WebSocketListener implements Cal
         modelRequest.setSequence(1);
         // 大模型特有参数
         modelRequest.setModel_name("bigmodel"); // 大模型名称
-        modelRequest.setEnable_punc(true); // 启用标点
-        modelRequest.setEnable_itn(false); // 是否启用ITN
-        modelRequest.setEnable_ddc(false); // 是否启用顺滑
+        modelRequest.setEnable_punc(request.isEnable_punc()); // 是否启用标点
+        modelRequest.setEnable_itn(request.isEnable_itn()); // 是否启用ITN
+        modelRequest.setEnable_ddc(false); 	// 默认关闭顺滑
 
         // 设置corpus和热词
         Corpus corpus = new Corpus();


### PR DESCRIPTION
# 🐞 Background
此前使用 openapi 的火山引擎语音识别发现有两个问题：
- 普通版的语音识别不支持开启标点预测，经检查发现需要手动在 `workflow` 字段中添加 `nlu_punctuate`字符，同时 `itn` 也需要通过字符串进行 append
- 大模型语音识别在多轮对话后，仅接收音频而不响应文本，但客户端并没有触发重连机制

# ✨ Features
- 火山引擎语音识别大模型版本适配器与官方示例逻辑对齐
- ITN 逆文本规范化 与 标点预测 可以通过请求体进行透传

本地测试工作正常:
<img width="1892" height="478" alt="image" src="https://github.com/user-attachments/assets/aa33696f-c97f-4155-a342-0f3eb6e8cfab" />



# 📚 References
- 豆包流式语音识别（小模型）: https://www.volcengine.com/docs/6561/80818
- 豆包大模型流式语音识别： https://www.volcengine.com/docs/6561/1354869