### PR TITLE
feat: enhance Vertex AI UsageMetadata with complete field mapping

### DIFF
--- a/api/server/src/main/java/com/ke/bella/openapi/protocol/completion/gemini/UsageMetadata.java
+++ b/api/server/src/main/java/com/ke/bella/openapi/protocol/completion/gemini/UsageMetadata.java
@@ -17,8 +17,14 @@ public class UsageMetadata {
     private Integer promptTokenCount;
     private Integer candidatesTokenCount;
     private Integer totalTokenCount;
+    private Integer toolUsePromptTokenCount;
+    private Integer thoughtsTokenCount;
+    private Integer cachedContentTokenCount;
     private List<TokensDetails> promptTokensDetails;
+    private List<TokensDetails> cacheTokensDetails;
     private List<TokensDetails> candidatesTokensDetails;
+    private List<TokensDetails> toolUsePromptTokensDetails;
+    private String trafficType;
 
 
     @Data
@@ -29,5 +35,14 @@ public class UsageMetadata {
     public static class TokensDetails {
         private String modality;
         private int tokenCount;
+    }
+
+    public enum Modality {
+        MODALITY_UNSPECIFIED,
+        TEXT,
+        IMAGE,
+        VIDEO,
+        AUDIO,
+        DOCUMENT
     }
 }


### PR DESCRIPTION
修复Vertex AI Usage Metadata丢失问题

- Add missing fields to UsageMetadata per Google Vertex AI API spec
  - toolUsePromptTokenCount: tokens from tool execution results
  - cachedContentTokenCount: tokens from cached content
  - thoughtsTokenCount: tokens from model reasoning
  - cacheTokensDetails: per-modality breakdown for cached content
  - toolUsePromptTokensDetails: per-modality breakdown for tool inputs
  - trafficType: traffic type identifier (ON_DEMAND/PROVISIONED_THROUGHPUT)

- Add Modality enum for type-safe modality handling
  - MODALITY_UNSPECIFIED, TEXT, IMAGE, VIDEO, AUDIO, DOCUMENT
  - Based on official ModalityTokenCount reference

- Enhance VertexConverter.convertUsage() method
  - Map cachedContentTokenCount to cache_read_tokens
  - Map thoughtsTokenCount to completion_tokens_details.reasoning_tokens
  - Extract AUDIO modality tokens from all token details lists
  - Process cacheTokensDetails for multi-modal token statistics
  - Replace hardcoded strings with Modality enum references

This improves compatibility with Google Vertex AI's complete usage metadata response structure and enables accurate token tracking for cached content, reasoning tokens, and multi-modal content.

🤖 Generated with [Claude Code](https://claude.ai/code)