### PR TITLE
fix: correct token usage calculation in Vertex AI to OpenAI conversion

### DIFF
--- a/api/server/src/main/java/com/ke/bella/openapi/protocol/completion/VertexConverter.java
+++ b/api/server/src/main/java/com/ke/bella/openapi/protocol/completion/VertexConverter.java
@@ -525,7 +525,7 @@ public class VertexConverter {
         
         CompletionResponse.TokenUsage.TokenUsageBuilder builder = CompletionResponse.TokenUsage.builder()
                 .prompt_tokens(usageMetadata.getPromptTokenCount() != null ? usageMetadata.getPromptTokenCount() : 0)
-                .completion_tokens(usageMetadata.getCandidatesTokenCount() != null ? usageMetadata.getCandidatesTokenCount() : 0)
+                .completion_tokens(calculateCompletionTokens(usageMetadata))
                 .total_tokens(usageMetadata.getTotalTokenCount() != null ? usageMetadata.getTotalTokenCount() : 0);
         
         if(usageMetadata.getCachedContentTokenCount() != null && usageMetadata.getCachedContentTokenCount() > 0) {
@@ -581,6 +581,12 @@ public class VertexConverter {
         }
         
         return builder.build();
+    }
+    
+    private static int calculateCompletionTokens(UsageMetadata usageMetadata) {
+        int candidateTokens = usageMetadata.getCandidatesTokenCount() != null ? usageMetadata.getCandidatesTokenCount() : 0;
+        int thoughtTokens = usageMetadata.getThoughtsTokenCount() != null ? usageMetadata.getThoughtsTokenCount() : 0;
+        return candidateTokens + thoughtTokens;
     }
     
     private static String convertFinishReason(String vertexFinishReason) {


### PR DESCRIPTION
Fix completion_tokens calculation to include both candidate tokens and reasoning tokens, ensuring consistency with OpenAI's usage format where completion_tokens represents the total of output and thinking tokens.

- Add calculateCompletionTokens() helper to sum candidatesTokenCount and thoughtsTokenCount
- Update convertUsage() to use the new calculation method
- Align token reporting with OpenAI spec: completion_tokens = output + reasoning

🤖 Generated with [Claude Code](https://claude.ai/code)