### PR TITLE
fix(auth): add thread-safe synchronization for Google credentials ref…

### DIFF
--- a/api/sdk/src/main/java/com/ke/bella/openapi/protocol/AuthorizationProperty.java
+++ b/api/sdk/src/main/java/com/ke/bella/openapi/protocol/AuthorizationProperty.java
@@ -21,6 +21,7 @@ import java.util.concurrent.ConcurrentHashMap;
 public class AuthorizationProperty implements IProtocolProperty {
 
     private static Map<String, GoogleCredentials> credentialsMap = new ConcurrentHashMap<>();
+    private static Map<String, Object> credentialsLockMap = new ConcurrentHashMap<>();
 
     private static final String GOOGLE_CLOUD_PLATFORM_SCOPE =
             "https://www.googleapis.com/auth/cloud-platform";
@@ -48,13 +49,18 @@ public class AuthorizationProperty implements IProtocolProperty {
 
     public String getApiKey() {
         if(type == AuthType.GOOGLE_AUTH) {
+            String secret = getSecret();
             try {
-                GoogleCredentials credentials = credentialsMap.computeIfAbsent(getSecret(), k -> getGoogleCredentials());
-                credentials.refreshIfExpired();
-                AccessToken accessToken = credentials.getAccessToken();
-                return accessToken.getTokenValue();
+                GoogleCredentials credentials = credentialsMap.computeIfAbsent(secret, k -> getGoogleCredentials());
+                Object lock = credentialsLockMap.computeIfAbsent(secret, k -> new Object());
+                synchronized (lock) {
+                    credentials.refreshIfExpired();
+                    AccessToken accessToken = credentials.getAccessToken();
+                    return accessToken.getTokenValue();
+                }
             } catch (IOException e) {
-                throw new RuntimeException("google auth error", e);
+                String secretPrefix = secret.substring(0, Math.min(20, secret.length()));
+                throw new RuntimeException("google auth error, secret prefix: " + secretPrefix + ", error: " + e.getMessage(), e);
             }
         } else {
             return apiKey;


### PR DESCRIPTION
…resh

Resolve high-concurrency race condition causing "google auth error" in production.

Problem:
- GoogleCredentials.refreshIfExpired() is not thread-safe
- Under high QPS (150M+ daily requests), multiple threads simultaneously accessing the same credentials object caused IOException
- Token expiration triggered refresh storms, amplifying the issue

Solution:
- Add per-secret lock map (credentialsLockMap) to synchronize refresh operations
- Each secret gets its own dedicated lock object via computeIfAbsent
- Only the refresh operation is synchronized, minimizing lock contention
- Enhanced error messages with secret prefix for better troubleshooting

Impact:
- Eliminates race conditions without performance degradation
- Different secrets remain independently locked (no cross-blocking)
- Memory overhead: ~16 bytes per secret (negligible)

🤖 Generated with [Claude Code](https://claude.ai/code)