### PR TITLE
feat(web_v2): Redesign overview page and fix development port

### DIFF
--- a/web_v2/package.json
+++ b/web_v2/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev -p 4000",
     "build": "next build",
     "start": "next start",
     "lint": "next lint"

--- a/web_v2/src/app/[locale]/(dashboard)/overview/components/code-example.tsx
+++ b/web_v2/src/app/[locale]/(dashboard)/overview/components/code-example.tsx
@@ -1,0 +1,101 @@
+"use client"
+
+import Link from "next/link"
+
+import { Button } from "@/components/common/button"
+import { Card, CardContent } from "@/components/common/card"
+import { useLanguage } from "@/components/providers/language-provider"
+
+export function CodeExample() {
+  const { t } = useLanguage()
+
+  return (
+    <div>
+      <div className="mb-4 flex items-center justify-between">
+        <h2 className="text-2xl font-bold">{t("quickStart")}</h2>
+        <div className="flex gap-2">
+          <Button variant="ghost" size="sm" asChild>
+            <Link href="/api-keys">{t("viewAPIKeys")}</Link>
+          </Button>
+          <Button variant="ghost" size="sm" asChild>
+            <Link href="/docs">{t("browseDocs")}</Link>
+          </Button>
+        </div>
+      </div>
+
+      <Card className="border-border/50 bg-card/50">
+        <CardContent className="p-6">
+          <div className="mb-3 flex items-center gap-2">
+            <span className="text-sm font-medium text-muted-foreground">Python</span>
+          </div>
+          <pre className="overflow-x-auto rounded-lg bg-muted/50 p-4 text-sm">
+            <code className="font-mono">
+              <span className="text-pink-400">from</span> <span className="text-foreground">openai</span>{" "}
+              <span className="text-pink-400">import</span> <span className="text-foreground">OpenAI</span>
+              {"\n\n"}
+              <span className="text-foreground">client</span> <span className="text-pink-400">=</span>{" "}
+              <span className="text-foreground">OpenAI</span>
+              <span className="text-yellow-400">(</span>
+              {"\n"}
+              {"  "}
+              <span className="text-foreground">api_key</span>
+              <span className="text-pink-400">=</span>
+              <span className="text-green-400">"your-api-key"</span>
+              <span className="text-yellow-400">,</span>
+              {"\n"}
+              {"  "}
+              <span className="text-foreground">base_url</span>
+              <span className="text-pink-400">=</span>
+              <span className="text-green-400">"https://api.example.com/v1"</span>
+              {"\n"}
+              <span className="text-yellow-400">)</span>
+              {"\n\n"}
+              <span className="text-foreground">response</span> <span className="text-pink-400">=</span>{" "}
+              <span className="text-foreground">client</span>
+              <span className="text-pink-400">.</span>
+              <span className="text-foreground">chat</span>
+              <span className="text-pink-400">.</span>
+              <span className="text-foreground">completions</span>
+              <span className="text-pink-400">.</span>
+              <span className="text-blue-400">create</span>
+              <span className="text-yellow-400">(</span>
+              {"\n"}
+              {"  "}
+              <span className="text-foreground">model</span>
+              <span className="text-pink-400">=</span>
+              <span className="text-green-400">"gpt-5-mini"</span>
+              <span className="text-yellow-400">,</span>
+              {"\n"}
+              {"  "}
+              <span className="text-foreground">messages</span>
+              <span className="text-pink-400">=</span>
+              <span className="text-yellow-400">[{"{"}</span>
+              <span className="text-green-400">"role"</span>
+              <span className="text-pink-400">:</span> <span className="text-green-400">"user"</span>
+              <span className="text-yellow-400">,</span> <span className="text-green-400">"content"</span>
+              <span className="text-pink-400">:</span> <span className="text-green-400">"Hello!"</span>
+              <span className="text-yellow-400">{"}"}]</span>
+              {"\n"}
+              <span className="text-yellow-400">)</span>
+              {"\n\n"}
+              <span className="text-blue-400">print</span>
+              <span className="text-yellow-400">(</span>
+              <span className="text-foreground">response</span>
+              <span className="text-pink-400">.</span>
+              <span className="text-foreground">choices</span>
+              <span className="text-yellow-400">[</span>
+              <span className="text-purple-400">0</span>
+              <span className="text-yellow-400">].</span>
+              <span className="text-foreground">message</span>
+              <span className="text-pink-400">.</span>
+              <span className="text-foreground">content</span>
+              <span className="text-yellow-400">)</span>
+            </code>
+          </pre>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}
+
+

--- a/web_v2/src/app/[locale]/(dashboard)/overview/components/hero-section.tsx
+++ b/web_v2/src/app/[locale]/(dashboard)/overview/components/hero-section.tsx
@@ -1,0 +1,35 @@
+"use client"
+
+import Link from "next/link"
+import { ArrowRight } from "lucide-react"
+
+import { Button } from "@/components/common/button"
+import { useLanguage } from "@/components/providers/language-provider"
+
+export function HeroSection() {
+  const { t } = useLanguage()
+
+  return (
+    <div className="mb-12">
+      <div className="mb-3 inline-flex items-center gap-2 rounded-full bg-primary/10 px-3 py-1 text-sm">
+        <span className="relative flex h-2 w-2">
+          <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-primary opacity-75"></span>
+          <span className="relative inline-flex h-2 w-2 rounded-full bg-primary"></span>
+        </span>
+        <span className="text-primary font-medium">{t("aiDeveloperPlatform")}</span>
+      </div>
+
+      <h1 className="mb-4 text-balance text-5xl font-bold tracking-tight">{t("fastestPathToProduction")}</h1>
+      <p className="mb-8 text-pretty text-xl text-muted-foreground">{t("homeDescription")}</p>
+
+      <Button size="lg" asChild>
+        <Link href="/models">
+          {t("startBuilding")}
+          <ArrowRight className="ml-2 h-4 w-4" />
+        </Link>
+      </Button>
+    </div>
+  )
+}
+
+

--- a/web_v2/src/app/[locale]/(dashboard)/overview/components/quick-actions.tsx
+++ b/web_v2/src/app/[locale]/(dashboard)/overview/components/quick-actions.tsx
@@ -1,0 +1,62 @@
+"use client"
+
+import Link from "next/link"
+import { Code, MessageSquare, Gauge, type LucideIcon } from "lucide-react"
+
+import { Card, CardDescription, CardHeader, CardTitle } from "@/components/common/card"
+import { useLanguage } from "@/components/providers/language-provider"
+
+type QuickActionItem = {
+  icon: LucideIcon
+  title: string
+  description: string
+  href: string
+}
+
+export function QuickActions() {
+  const { t } = useLanguage()
+
+  const quickActions: QuickActionItem[] = [
+    {
+      icon: Code,
+      title: t("browseModels"),
+      description: t("browseModelsDesc"),
+      href: "/models",
+    },
+    {
+      icon: MessageSquare,
+      title: t("testInPlayground"),
+      description: t("testInPlaygroundDesc"),
+      href: "/playground",
+    },
+    {
+      icon: Gauge,
+      title: t("monitorUsage"),
+      description: t("monitorUsageDesc"),
+      href: "/logs",
+    },
+  ]
+
+  return (
+    <div className="mb-16 grid grid-cols-1 gap-4 md:grid-cols-3">
+      {quickActions.map((action, index) => {
+        const Icon = action.icon
+        return (
+          <Link key={index} href={action.href}>
+            <Card className="h-full border-border/50 transition-all hover:border-primary/50 hover:shadow-md">
+              <CardHeader>
+                <div className="mb-2 flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10">
+                  <Icon className="h-5 w-5 text-primary" />
+                </div>
+                <CardTitle className="text-lg">{action.title}</CardTitle>
+                <CardDescription>{action.description}</CardDescription>
+              </CardHeader>
+            </Card>
+          </Link>
+        )
+      })}
+    </div>
+  )
+}
+
+

--- a/web_v2/src/app/[locale]/(dashboard)/overview/components/whats-new.tsx
+++ b/web_v2/src/app/[locale]/(dashboard)/overview/components/whats-new.tsx
@@ -1,0 +1,78 @@
+"use client"
+
+import { Sparkles, Code, Zap, TrendingUp, type LucideIcon } from "lucide-react"
+
+import { Card, CardContent } from "@/components/common/card"
+import { useLanguage } from "@/components/providers/language-provider"
+
+type WhatsNewItem = {
+  icon: LucideIcon
+  title: string
+  description: string
+  badge?: string
+}
+
+export function WhatsNew() {
+  const { t } = useLanguage()
+
+  const whatsNew: WhatsNewItem[] = [
+    {
+      icon: Sparkles,
+      title: t("gpt5ProTitle"),
+      description: t("gpt5ProDesc"),
+      badge: t("newFeature"),
+    },
+    {
+      icon: Code,
+      title: t("sora2Title"),
+      description: t("sora2Desc"),
+      badge: t("beta"),
+    },
+    {
+      icon: Zap,
+      title: t("realtimeApiTitle"),
+      description: t("realtimeApiDesc"),
+      badge: t("newFeature"),
+    },
+    {
+      icon: TrendingUp,
+      title: t("functionCallingTitle"),
+      description: t("functionCallingDesc"),
+    },
+  ]
+
+  return (
+    <div className="mb-16">
+      <h2 className="mb-6 text-2xl font-bold">{t("whatsNew")}</h2>
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+        {whatsNew.map((item, index) => {
+          const Icon = item.icon
+          return (
+            <Card key={index} className="border-border/50 transition-colors hover:border-primary/30">
+              <CardContent className="p-6">
+                <div className="flex items-start gap-4">
+                  <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-primary/10">
+                    <Icon className="h-5 w-5 text-primary" />
+                  </div>
+                  <div className="flex-1">
+                    <div className="mb-1 flex items-center gap-2">
+                      <h3 className="font-semibold">{item.title}</h3>
+                      {item.badge && (
+                        <span className="rounded-full bg-primary/20 px-2 py-0.5 text-xs font-medium text-primary">
+                          {item.badge}
+                        </span>
+                      )}
+                    </div>
+                    <p className="text-sm text-muted-foreground">{item.description}</p>
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
+

--- a/web_v2/src/app/[locale]/(dashboard)/overview/page.tsx
+++ b/web_v2/src/app/[locale]/(dashboard)/overview/page.tsx
@@ -1,7 +1,25 @@
+"use client"
+
+import { TopBar } from "@/components/layout/top-bar"
+
+import { HeroSection } from "./components/hero-section"
+import { QuickActions } from "./components/quick-actions"
+import { WhatsNew } from "./components/whats-new"
+import { CodeExample } from "./components/code-example"
+
 export default function OverviewPage() {
   return (
-    <div className="p-8">
-      主页
+    <div className="flex h-screen flex-col overflow-hidden">
+      <TopBar />
+
+      <div className="flex-1 overflow-y-auto">
+        <div className="container px-4 py-8">
+          <HeroSection />
+          <QuickActions />
+          <WhatsNew />
+          <CodeExample />
+        </div>
+      </div>
     </div>
-  );
+  )
 }

--- a/web_v2/src/components/common/card.tsx
+++ b/web_v2/src/components/common/card.tsx
@@ -1,0 +1,79 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+const Card = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn(
+      "rounded-lg border bg-card text-card-foreground shadow-sm",
+      className
+    )}
+    {...props}
+  />
+))
+Card.displayName = "Card"
+
+const CardHeader = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("flex flex-col space-y-1.5 p-6", className)}
+    {...props}
+  />
+))
+CardHeader.displayName = "CardHeader"
+
+const CardTitle = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn(
+      "text-2xl font-semibold leading-none tracking-tight",
+      className
+    )}
+    {...props}
+  />
+))
+CardTitle.displayName = "CardTitle"
+
+const CardDescription = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+))
+CardDescription.displayName = "CardDescription"
+
+const CardContent = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn("p-6 pt-0", className)} {...props} />
+))
+CardContent.displayName = "CardContent"
+
+const CardFooter = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("flex items-center p-6 pt-0", className)}
+    {...props}
+  />
+))
+CardFooter.displayName = "CardFooter"
+
+export { Card, CardHeader, CardFooter, CardTitle, CardDescription, CardContent }


### PR DESCRIPTION
- Add Hero section, quick access, what's new, and Quick Start atom component to overview page with i18n support
- Add reusable Card component for pages
- Fix dev script to use port 4000
- 概览页增加 Hero/快捷入口/更新动态/Quick Start原子组件，并接入多语言文案
- 新增通用 Card 组件供页面复用
- dev 脚本固定使用 4000 端口