### PR TITLE
fix: preserve empty strings and whitespace in VertexConverter content…

### DIFF
--- a/api/server/src/main/java/com/ke/bella/openapi/protocol/completion/VertexConverter.java
+++ b/api/server/src/main/java/com/ke/bella/openapi/protocol/completion/VertexConverter.java
@@ -216,19 +216,17 @@ public class VertexConverter {
         // Handle content (can be String, Map, or List for multimodal)
         if (content instanceof String) {
             String textContent = (String) content;
-            if (StringUtils.hasText(textContent)) {
-                Part part = applyThoughtSignature(
-                    Part.builder().text(textContent),
-                    thoughtSignature
-                ).build();
-                parts.add(part);
-            }
+            Part part = applyThoughtSignature(
+                Part.builder().text(textContent),
+                thoughtSignature
+            ).build();
+            parts.add(part);
         } else if (content instanceof Map) {
             // Handle content as a map with text field
             @SuppressWarnings("unchecked")
             Map<String, Object> contentMap = (Map<String, Object>) content;
             String text = (String) contentMap.get("text");
-            if (StringUtils.hasText(text)) {
+            if (text != null) {
                 Part part = applyThoughtSignature(
                     Part.builder().text(text),
                     thoughtSignature
@@ -255,10 +253,13 @@ public class VertexConverter {
         switch (type) {
             case "text":
                 String text = (String) contentItem.get("text");
-                return applyThoughtSignature(
-                    Part.builder().text(text),
-                    thoughtSignature
-                ).build();
+                if (text != null) {
+                    return applyThoughtSignature(
+                        Part.builder().text(text),
+                        thoughtSignature
+                    ).build();
+                }
+                return null;
             case "image_url":
                 @SuppressWarnings("unchecked")
                 Map<String, Object> imageUrl = (Map<String, Object>) contentItem.get("image_url");

--- a/api/server/src/test/java/com/ke/bella/openapi/protocol/completion/VertexConverterTest.java
+++ b/api/server/src/test/java/com/ke/bella/openapi/protocol/completion/VertexConverterTest.java
@@ -1,11 +1,15 @@
 package com.ke.bella.openapi.protocol.completion;
 
+import com.ke.bella.openapi.protocol.completion.gemini.Content;
+import com.ke.bella.openapi.protocol.completion.gemini.GeminiRequest;
 import com.ke.bella.openapi.protocol.completion.gemini.UsageMetadata;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -493,5 +497,152 @@ class VertexConverterTest {
 		assertEquals(0, result.getPrompt_tokens());
 		assertEquals(0, result.getCompletion_tokens());
 		assertEquals(0, result.getTotal_tokens());
+	}
+
+	@Test
+	void testConvertToVertexRequest_WithEmptyStringContent_ShouldPreserveEmptyString() {
+		CompletionRequest request = CompletionRequest.builder()
+				.messages(Arrays.asList(
+						Message.builder()
+								.role("user")
+								.content("")
+								.build()
+				))
+				.build();
+
+		VertexProperty property = new VertexProperty();
+		property.setSupportSystemInstruction(true);
+
+		GeminiRequest result = VertexConverter.convertToVertexRequest(request, property);
+
+		assertNotNull(result);
+		assertNotNull(result.getContents());
+		assertEquals(1, result.getContents().size());
+		Content content = result.getContents().get(0);
+		assertEquals("user", content.getRole());
+		assertNotNull(content.getParts());
+		assertEquals(1, content.getParts().size());
+		assertEquals("", content.getParts().get(0).getText());
+	}
+
+	@Test
+	void testConvertToVertexRequest_WithWhitespaceContent_ShouldPreserveWhitespace() {
+		CompletionRequest request = CompletionRequest.builder()
+				.messages(Arrays.asList(
+						Message.builder()
+								.role("user")
+								.content("   ")
+								.build()
+				))
+				.build();
+
+		VertexProperty property = new VertexProperty();
+		property.setSupportSystemInstruction(true);
+
+		GeminiRequest result = VertexConverter.convertToVertexRequest(request, property);
+
+		assertNotNull(result);
+		assertNotNull(result.getContents());
+		assertEquals(1, result.getContents().size());
+		Content content = result.getContents().get(0);
+		assertEquals("user", content.getRole());
+		assertNotNull(content.getParts());
+		assertEquals(1, content.getParts().size());
+		assertEquals("   ", content.getParts().get(0).getText());
+	}
+
+	@Test
+	void testConvertToVertexRequest_WithMultimodalEmptyTextContent_ShouldPreserveEmptyText() {
+		List<Map<String, Object>> contentList = new ArrayList<>();
+		
+		Map<String, Object> textPart = new HashMap<>();
+		textPart.put("type", "text");
+		textPart.put("text", "");
+		contentList.add(textPart);
+
+		CompletionRequest request = CompletionRequest.builder()
+				.messages(Arrays.asList(
+						Message.builder()
+								.role("user")
+								.content(contentList)
+								.build()
+				))
+				.build();
+
+		VertexProperty property = new VertexProperty();
+		property.setSupportSystemInstruction(true);
+
+		GeminiRequest result = VertexConverter.convertToVertexRequest(request, property);
+
+		assertNotNull(result);
+		assertNotNull(result.getContents());
+		assertEquals(1, result.getContents().size());
+		Content content = result.getContents().get(0);
+		assertEquals("user", content.getRole());
+		assertNotNull(content.getParts());
+		assertEquals(1, content.getParts().size());
+		assertEquals("", content.getParts().get(0).getText());
+	}
+
+	@Test
+	void testConvertToVertexRequest_WithMultimodalWhitespaceTextContent_ShouldPreserveWhitespace() {
+		List<Map<String, Object>> contentList = new ArrayList<>();
+		
+		Map<String, Object> textPart = new HashMap<>();
+		textPart.put("type", "text");
+		textPart.put("text", "  \t\n  ");
+		contentList.add(textPart);
+
+		CompletionRequest request = CompletionRequest.builder()
+				.messages(Arrays.asList(
+						Message.builder()
+								.role("user")
+								.content(contentList)
+								.build()
+				))
+				.build();
+
+		VertexProperty property = new VertexProperty();
+		property.setSupportSystemInstruction(true);
+
+		GeminiRequest result = VertexConverter.convertToVertexRequest(request, property);
+
+		assertNotNull(result);
+		assertNotNull(result.getContents());
+		assertEquals(1, result.getContents().size());
+		Content content = result.getContents().get(0);
+		assertEquals("user", content.getRole());
+		assertNotNull(content.getParts());
+		assertEquals(1, content.getParts().size());
+		assertEquals("  \t\n  ", content.getParts().get(0).getText());
+	}
+
+	@Test
+	void testConvertToVertexRequest_WithMapContentEmptyText_ShouldPreserveEmptyText() {
+		Map<String, Object> contentMap = new HashMap<>();
+		contentMap.put("text", "");
+
+		CompletionRequest request = CompletionRequest.builder()
+				.messages(Arrays.asList(
+						Message.builder()
+								.role("user")
+								.content(contentMap)
+								.build()
+				))
+				.build();
+
+		VertexProperty property = new VertexProperty();
+		property.setSupportSystemInstruction(true);
+
+		GeminiRequest result = VertexConverter.convertToVertexRequest(request, property);
+
+		assertNotNull(result);
+		assertNotNull(result.getContents());
+		assertEquals(1, result.getContents().size());
+		Content content = result.getContents().get(0);
+		assertEquals("user", content.getRole());
+		assertNotNull(content.getParts());
+		assertEquals(1, content.getParts().size());
+		assertEquals("", content.getParts().get(0).getText());
 	}
 }


### PR DESCRIPTION
… handling

Fixed a bug in VertexConverter.addContentToParts() where empty strings and whitespace-only content were being filtered out due to using StringUtils.hasText(). This caused content loss when messages contained intentional empty strings or whitespace characters.

Changes:
- Remove StringUtils.hasText() check for String content (line 217-223) Since instanceof String already ensures non-null, no additional null check needed
- Replace StringUtils.hasText() with null check in addContentToParts() for Map content (line 231) Map.get() can return null, so null check is necessary
- Add null check in convertContentItem() for "text" type multimodal content (line 256) Map.get() can return null, so null check is necessary

These changes ensure that all non-null text content is preserved and passed to
Vertex AI API, including empty strings (""), whitespace ("   "), and special
whitespace characters ("\t", "\n", etc.).

Added comprehensive test coverage:
- testConvertToVertexRequest_WithEmptyStringContent_ShouldPreserveEmptyString
- testConvertToVertexRequest_WithWhitespaceContent_ShouldPreserveWhitespace
- testConvertToVertexRequest_WithMultimodalEmptyTextContent_ShouldPreserveEmptyText
- testConvertToVertexRequest_WithMultimodalWhitespaceTextContent_ShouldPreserveWhitespace
- testConvertToVertexRequest_WithMapContentEmptyText_ShouldPreserveEmptyText

🤖 Generated with [Claude Code](https://claude.ai/code)