### PR TITLE
fix: support additionalProperties as both boolean and schema object in /v1/messages

### DIFF
--- a/api/sdk/src/main/java/com/ke/bella/openapi/protocol/message/MessageRequest.java
+++ b/api/sdk/src/main/java/com/ke/bella/openapi/protocol/message/MessageRequest.java
@@ -424,7 +424,7 @@ public class MessageRequest implements IMemoryClearable {
         private String type; // e.g., "object"
         private Object properties;
         private List<String> required;
-        private boolean additionalProperties;
+        private Object additionalProperties; // Can be Boolean or schema object
     }
 
     @Data

--- a/api/sdk/src/main/java/com/ke/bella/openapi/protocol/message/TransferFromCompletionsUtils.java
+++ b/api/sdk/src/main/java/com/ke/bella/openapi/protocol/message/TransferFromCompletionsUtils.java
@@ -333,11 +333,16 @@ public class TransferFromCompletionsUtils {
         
         if (apiTool.getInputSchema() != null) {
             MessageRequest.InputSchema schema = apiTool.getInputSchema();
+            // Convert additionalProperties from Object to Boolean
+            Boolean additionalProps = null;
+            if (schema.getAdditionalProperties() instanceof Boolean) {
+                additionalProps = (Boolean) schema.getAdditionalProperties();
+            }
             Message.Function.FunctionParameter.FunctionParameterBuilder paramBuilder = Message.Function.FunctionParameter.builder()
                     .type(schema.getType())
                     .properties(schema.getProperties())
                     .required(schema.getRequired())
-                    .additionalProperties(schema.isAdditionalProperties());
+                    .additionalProperties(additionalProps);
             functionBuilder.parameters(paramBuilder.build());
         }
         

--- a/api/sdk/src/main/java/com/ke/bella/openapi/protocol/message/TransferToCompletionsUtils.java
+++ b/api/sdk/src/main/java/com/ke/bella/openapi/protocol/message/TransferToCompletionsUtils.java
@@ -390,15 +390,15 @@ public class TransferToCompletionsUtils {
             Message.Function.FunctionParameter params = tool.getFunction().getParameters();
             MessageRequest.InputSchema.InputSchemaBuilder schemaBuilder = MessageRequest.InputSchema.builder()
                     .type(params.getType())
-                    .additionalProperties(Boolean.TRUE == params.getAdditionalProperties());
-            
+                    .additionalProperties(params.getAdditionalProperties()); // Keep as Object (Boolean or schema)
+
             if (params.getProperties() != null) {
                 schemaBuilder.properties(params.getProperties());
             }
             if (params.getRequired() != null) {
                 schemaBuilder.required(params.getRequired());
             }
-            
+
             toolBuilder.inputSchema(schemaBuilder.build());
         }
         


### PR DESCRIPTION
## 问题描述

修复 `/v1/messages` 接口中的 JSON 反序列化错误。当工具的 `input_schema` 中 `additionalProperties` 字段为对象类型时，会抛出以下错误：

Fixes #427

```
Cannot deserialize instance of boolean out of START_OBJECT token
```

### 错误信息
```json
{
  "error": {
    "code": "400",
    "message": "JSON parse error: Cannot deserialize instance of boolean out of START_OBJECT token; nested exception is com.fasterxml.jackson.databind.exc.MismatchedInputException: Cannot deserialize instance of boolean out of START_OBJECT token\n at [Source: (PushbackInputStream); line: 1, column: 55862] (through reference chain: com.ke.bella.openapi.protocol.message.MessageRequest[\"tools\"]->java.util.ArrayList[5]->com.ke.bella.openapi.protocol.message.MessageRequest$Tool[\"input_schema\"]->com.ke.bella.openapi.protocol.message.MessageRequest$InputSchema[\"additionalProperties\"])"
  }
}
```

### 根本原因

根据 [JSON Schema 规范](https://json-schema.org/understanding-json-schema/reference/object#additionalproperties)，`additionalProperties` 字段可以是：
1. **布尔值** (`true`/`false`) - 允许或禁止额外属性
2. **Schema 对象** - 定义额外属性必须遵循的验证规则

但原代码中该字段被定义为 `boolean` 原始类型，无法接受对象类型。

## 解决方案

### 1. 修改数据模型 (MessageRequest.java)
```java
// 修改前
private boolean additionalProperties;

// 修改后
private Object additionalProperties; // Can be Boolean or schema object
```

### 2. 更新类型转换逻辑

#### TransferFromCompletionsUtils.java
添加类型检查，安全地将 `Object` 转换为 `Boolean`：
```java
Boolean additionalProps = null;
if (schema.getAdditionalProperties() instanceof Boolean) {
    additionalProps = (Boolean) schema.getAdditionalProperties();
}
```

#### TransferToCompletionsUtils.java
直接传递 `Object` 值，保留类型信息：
```java
.additionalProperties(params.getAdditionalProperties())
```

## 影响范围

✅ **所有协议适配器都已验证兼容**：

| 组件 | 处理方式 | 影响 |
|------|---------|------|
| AwsMessageAdaptor | 直接序列化 MessageRequest | ✅ Jackson 自动处理 |
| AnthropicAdaptor | 直接序列化 MessageRequest | ✅ Jackson 自动处理 |
| AwsCompletionConverter | JacksonUtils.toMap() | ✅ 自动转换 |
| VertexConverter (Gemini) | 传递 FunctionParameter | ✅ 兼容 Boolean 类型 |

## 测试用例

支持以下两种使用场景：

### 场景 1: additionalProperties 为布尔值
```json
{
  "tools": [{
    "input_schema": {
      "type": "object",
      "properties": {
        "name": {"type": "string"}
      },
      "additionalProperties": false
    }
  }]
}
```

### 场景 2: additionalProperties 为 schema 对象
```json
{
  "tools": [{
    "input_schema": {
      "type": "object",
      "properties": {
        "name": {"type": "string"}
      },
      "additionalProperties": {
        "type": "string",
        "minLength": 1
      }
    }
  }]
}
```

## 向后兼容性

✅ 完全向后兼容，现有使用布尔值的代码不受影响

## 修改文件

- `api/sdk/src/main/java/com/ke/bella/openapi/protocol/message/MessageRequest.java`
- `api/sdk/src/main/java/com/ke/bella/openapi/protocol/message/TransferFromCompletionsUtils.java`
- `api/sdk/src/main/java/com/ke/bella/openapi/protocol/message/TransferToCompletionsUtils.java`

## Checklist

- [x] 代码符合 JSON Schema 标准
- [x] 所有协议适配器兼容性已验证
- [x] 向后兼容现有用法
- [x] 添加了详细的代码注释