### PR TITLE
fix: support additionalProperties as Object in FunctionParameter

### DIFF
--- a/api/sdk/src/main/java/com/ke/bella/openapi/protocol/completion/Message.java
+++ b/api/sdk/src/main/java/com/ke/bella/openapi/protocol/completion/Message.java
@@ -172,7 +172,7 @@ public class Message implements Serializable {
             private String type;
             private List<String> required;
             private Object properties;
-            private Boolean additionalProperties;
+            private Object additionalProperties;
         }
     }
 

--- a/api/sdk/src/main/java/com/ke/bella/openapi/protocol/message/TransferFromCompletionsUtils.java
+++ b/api/sdk/src/main/java/com/ke/bella/openapi/protocol/message/TransferFromCompletionsUtils.java
@@ -333,16 +333,11 @@ public class TransferFromCompletionsUtils {
         
         if (apiTool.getInputSchema() != null) {
             MessageRequest.InputSchema schema = apiTool.getInputSchema();
-            // Convert additionalProperties from Object to Boolean
-            Boolean additionalProps = null;
-            if (schema.getAdditionalProperties() instanceof Boolean) {
-                additionalProps = (Boolean) schema.getAdditionalProperties();
-            }
             Message.Function.FunctionParameter.FunctionParameterBuilder paramBuilder = Message.Function.FunctionParameter.builder()
                     .type(schema.getType())
                     .properties(schema.getProperties())
                     .required(schema.getRequired())
-                    .additionalProperties(additionalProps);
+                    .additionalProperties(schema.getAdditionalProperties());
             functionBuilder.parameters(paramBuilder.build());
         }
         


### PR DESCRIPTION
Extends the fix from commit 9e21faab to also handle FunctionParameter. This ensures consistent handling of additionalProperties across both /v1/messages (InputSchema) and /v1/completions (FunctionParameter).

Problem:
- FunctionParameter.additionalProperties was defined as Boolean
- According to JSON Schema spec, it can be either boolean or schema object
- Inconsistent with the previous fix for InputSchema

Changes:
1. Message.FunctionParameter.additionalProperties: Boolean → Object
   - Now supports both Boolean values and schema objects

2. TransferFromCompletionsUtils:
   - Removed Boolean conversion logic
   - Directly passes Object value to preserve type information

Impact:
- Fully compatible with JSON Schema standard
- Backward compatible with existing boolean usage
- Consistent behavior across all tool/function schemas

🤖 Generated with [Claude Code](https://claude.ai/code)