### PR TITLE
refactor: remove Long to String serialization from JacksonUtils

### DIFF
--- a/api/sdk/src/main/java/com/ke/bella/openapi/utils/JacksonUtils.java
+++ b/api/sdk/src/main/java/com/ke/bella/openapi/utils/JacksonUtils.java
@@ -251,12 +251,6 @@ public class JacksonUtils {
                 .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
                 .setTimeZone(TimeZone.getTimeZone("Asia/Shanghai"));
 
-        // 序列化成json时，将所有的Long变成string，以解决js中的精度丢失。
-        SimpleModule simpleModule = new SimpleModule();
-        simpleModule.addSerializer(Long.class, ToStringSerializer.instance);
-        simpleModule.addSerializer(Long.TYPE, ToStringSerializer.instance);
-        objectMapper.registerModule(simpleModule);
-
         // 忽略不存在的字段
         objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
         // 空值不序列化


### PR DESCRIPTION
Remove the automatic Long-to-String conversion in JSON serialization that was added to handle JavaScript precision loss issues.

Rationale:
- This global conversion affects all Long values across the entire API
- Should be handled selectively on frontend or specific endpoints
- Causes unexpected behavior when clients expect numeric values
- Better to use @JsonSerialize annotation on specific fields if needed

Impact:
- Long values now serialize as numbers (JSON standard behavior)
- Clients handling large numbers should implement their own precision handling
- More predictable JSON serialization behavior

🤖 Generated with [Claude Code](https://claude.ai/code)