### PR TITLE
feat: add OpenAI Responses API direct channel support with tool pricing #392

### DIFF
--- a/api/sdk/src/main/java/com/ke/bella/openapi/protocol/Callbacks.java
+++ b/api/sdk/src/main/java/com/ke/bella/openapi/protocol/Callbacks.java
@@ -166,4 +166,11 @@ public interface Callbacks {
         }
     }
 
+    interface ResponsesApiSseCallback extends Callbacks {
+        void onEvent(String eventId, String eventType, String eventData);
+
+        void onComplete();
+
+        void onError(ChannelException exception);
+    }
 }

--- a/api/sdk/src/main/java/com/ke/bella/openapi/protocol/completion/ResponsesApiRequest.java
+++ b/api/sdk/src/main/java/com/ke/bella/openapi/protocol/completion/ResponsesApiRequest.java
@@ -1,16 +1,20 @@
 package com.ke.bella.openapi.protocol.completion;
 
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.ke.bella.openapi.protocol.IMemoryClearable;
 import com.ke.bella.openapi.protocol.ITransfer;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-
-import java.util.List;
-import java.util.Map;
 
 /**
  * OpenAI Responses API request format
@@ -73,12 +77,12 @@ public class ResponsesApiRequest implements IMemoryClearable, ITransfer {
      * Whether to store conversation state
      * For chat completion simulation, this is false
      */
-    private Boolean store = false;
+    private Boolean store;
 
     /**
      * Background processing mode
      */
-    private Boolean background = false;
+    private Boolean background;
 
     /**
      * Previous response ID for conversation continuation
@@ -116,6 +120,33 @@ public class ResponsesApiRequest implements IMemoryClearable, ITransfer {
      */
     private String prompt_cache_key;
 
+    /**
+     * Extra body fields for vendor-specific parameters
+     * Prefixed with underscore to indicate internal usage
+     */
+    @JsonIgnore
+    private Map<String, Object> _extra_body;
+
+    /**
+     * Flatten _extra_body fields to the outer JSON during serialization
+     */
+    @JsonAnyGetter
+    public Map<String, Object> getExtraBodyFields() {
+        return _extra_body != null && !_extra_body.isEmpty() ? _extra_body : null;
+    }
+
+    /**
+     * Handle unknown properties during deserialization and store them in
+     * _extra_body
+     */
+    @JsonAnySetter
+    public void setExtraBodyField(String key, Object value) {
+        if(_extra_body == null) {
+            _extra_body = new HashMap<>();
+        }
+        _extra_body.put(key, value);
+    }
+
     @Data
     @NoArgsConstructor
     @Builder
@@ -133,6 +164,25 @@ public class ResponsesApiRequest implements IMemoryClearable, ITransfer {
          * auto, concise, or detailed.
          */
         private String summary;
+
+        /**
+         * Extra fields for vendor-specific parameters
+         */
+        @JsonIgnore
+        private Map<String, Object> _extra_body;
+
+        @JsonAnyGetter
+        public Map<String, Object> getExtraBodyFields() {
+            return _extra_body != null && !_extra_body.isEmpty() ? _extra_body : null;
+        }
+
+        @JsonAnySetter
+        public void setExtraBodyField(String key, Object value) {
+            if(_extra_body == null) {
+                _extra_body = new HashMap<>();
+            }
+            _extra_body.put(key, value);
+        }
     }
 
     @Data
@@ -165,6 +215,25 @@ public class ResponsesApiRequest implements IMemoryClearable, ITransfer {
          * Whether to use strict mode
          */
         private Boolean strict;
+
+        /**
+         * Extra fields for vendor-specific parameters
+         */
+        @JsonIgnore
+        private Map<String, Object> _extra_body;
+
+        @JsonAnyGetter
+        public Map<String, Object> getExtraBodyFields() {
+            return _extra_body != null && !_extra_body.isEmpty() ? _extra_body : null;
+        }
+
+        @JsonAnySetter
+        public void setExtraBodyField(String key, Object value) {
+            if(_extra_body == null) {
+                _extra_body = new HashMap<>();
+            }
+            _extra_body.put(key, value);
+        }
     }
 
     @Data
@@ -212,6 +281,25 @@ public class ResponsesApiRequest implements IMemoryClearable, ITransfer {
          * Status (for function calls)
          */
         private String status;
+
+        /**
+         * Extra fields for vendor-specific parameters
+         */
+        @JsonIgnore
+        private Map<String, Object> _extra_body;
+
+        @JsonAnyGetter
+        public Map<String, Object> getExtraBodyFields() {
+            return _extra_body != null && !_extra_body.isEmpty() ? _extra_body : null;
+        }
+
+        @JsonAnySetter
+        public void setExtraBodyField(String key, Object value) {
+            if(_extra_body == null) {
+                _extra_body = new HashMap<>();
+            }
+            _extra_body.put(key, value);
+        }
     }
 
     @Data
@@ -249,6 +337,25 @@ public class ResponsesApiRequest implements IMemoryClearable, ITransfer {
          * Image detail level
          */
         private String detail;
+
+        /**
+         * Extra fields for vendor-specific parameters
+         */
+        @JsonIgnore
+        private Map<String, Object> _extra_body;
+
+        @JsonAnyGetter
+        public Map<String, Object> getExtraBodyFields() {
+            return _extra_body != null && !_extra_body.isEmpty() ? _extra_body : null;
+        }
+
+        @JsonAnySetter
+        public void setExtraBodyField(String key, Object value) {
+            if(_extra_body == null) {
+                _extra_body = new HashMap<>();
+            }
+            _extra_body.put(key, value);
+        }
     }
 
     // 内存清理相关字段和方法
@@ -266,6 +373,9 @@ public class ResponsesApiRequest implements IMemoryClearable, ITransfer {
             }
             if(this.metadata != null) {
                 this.metadata.clear();
+            }
+            if(this._extra_body != null) {
+                this._extra_body.clear();
             }
             this.reasoning = null;
 

--- a/api/sdk/src/main/java/com/ke/bella/openapi/protocol/completion/ResponsesApiResponse.java
+++ b/api/sdk/src/main/java/com/ke/bella/openapi/protocol/completion/ResponsesApiResponse.java
@@ -1,5 +1,8 @@
 package com.ke.bella.openapi.protocol.completion;
 
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.ke.bella.openapi.protocol.OpenapiResponse;
 import lombok.AllArgsConstructor;
@@ -8,6 +11,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -80,6 +84,30 @@ public class ResponsesApiResponse extends OpenapiResponse {
      * Whether processed in background
      */
     private Boolean background;
+
+    /**
+     * Bella internal response metadata
+     */
+    private BellaResponse _bella_response;
+
+    /**
+     * Extra body fields for vendor-specific parameters
+     */
+    @JsonIgnore
+    private Map<String, Object> _extra_body;
+
+    @JsonAnyGetter
+    public Map<String, Object> getExtraBodyFields() {
+        return _extra_body != null && !_extra_body.isEmpty() ? _extra_body : null;
+    }
+
+    @JsonAnySetter
+    public void setExtraBodyField(String key, Object value) {
+        if(_extra_body == null) {
+            _extra_body = new HashMap<>();
+        }
+        _extra_body.put(key, value);
+    }
 
     @Data
     @NoArgsConstructor
@@ -203,6 +231,37 @@ public class ResponsesApiResponse extends OpenapiResponse {
          * Reasoning tokens (for reasoning models)
          */
         private OutputTokensDetail output_tokens_details;
+
+        /**
+         * Tool usage count map (for tool-based billing)
+         * Example: {"web_search": 1}
+         */
+        private Map<String, Integer> tool_usage;
+
+        /**
+         * Detailed tool usage breakdown (for source-specific billing)
+         * Example: {"web_search": {"search_engine": 1, "toutiao": 1}}
+         */
+        private Map<String, Map<String, Integer>> tool_usage_details;
+
+        /**
+         * Extra body fields for vendor-specific parameters
+         */
+        @JsonIgnore
+        private Map<String, Object> _extra_body;
+
+        @JsonAnyGetter
+        public Map<String, Object> getExtraBodyFields() {
+            return _extra_body != null && !_extra_body.isEmpty() ? _extra_body : null;
+        }
+
+        @JsonAnySetter
+        public void setExtraBodyField(String key, Object value) {
+            if(_extra_body == null) {
+                _extra_body = new HashMap<>();
+            }
+            _extra_body.put(key, value);
+        }
     }
 
     @Data
@@ -237,5 +296,17 @@ public class ResponsesApiResponse extends OpenapiResponse {
          * Reasoning summary
          */
         private String summary;
+    }
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class BellaResponse {
+        /**
+         * Channel code that was used to process this request
+         */
+        private String channel_code;
     }
 }

--- a/api/sdk/src/main/java/com/ke/bella/openapi/protocol/completion/ResponsesPriceInfo.java
+++ b/api/sdk/src/main/java/com/ke/bella/openapi/protocol/completion/ResponsesPriceInfo.java
@@ -1,0 +1,176 @@
+package com.ke.bella.openapi.protocol.completion;
+
+import java.math.BigDecimal;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.google.common.collect.ImmutableSortedMap;
+import com.ke.bella.openapi.protocol.IProtocolProperty;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ResponsesPriceInfo implements IProtocolProperty {
+
+    /**
+     * 价格单位：分/千token
+     */
+    private String unit = "分/千token";
+
+    /**
+     * 阶梯价格列表（用于token计费）
+     * 支持根据输入输出token数量匹配不同的价格区间
+     */
+    private List<Tier> tiers;
+
+    /**
+     * 工具使用价格配置（分/次）
+     * 用于基于工具调用的计费，如 Doubao 的 web_search
+     * Key: 工具名称（如 "web_search", "code_interpreter"）
+     * Value: 单价（分/次）
+     * 示例: {"web_search": 0.5, "code_interpreter": 1.0}
+     */
+    private Map<String, BigDecimal> toolPrices;
+
+    @Override
+    public Map<String, String> description() {
+        return ImmutableSortedMap.of(
+                "tiers", "阶梯价格列表(用于token计费,单位:分/千token)",
+                "toolPrices", "工具调用价格配置(Map<工具名,单价(分/次)>,可选)");
+    }
+
+    @Data
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class Tier {
+        private RangePrice inputRangePrice;
+        private List<RangePrice> outputRangePrices;
+
+        public boolean validateTier() {
+            if(inputRangePrice == null || !inputRangePrice.validateRangePrice()) {
+                return false;
+            }
+
+            if(outputRangePrices != null) {
+                if(outputRangePrices.isEmpty()) {
+                    return false;
+                }
+                return outputRangePrices.stream().allMatch(RangePrice::validateRangePrice);
+            }
+            return true;
+        }
+    }
+
+    @Data
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class RangePrice {
+        private int minToken;
+        private int maxToken;
+        private BigDecimal input;
+        private BigDecimal output;
+        private BigDecimal cachedInput;
+        private BigDecimal reasoningOutput;
+
+        public boolean match(int token) {
+            if(token == 0 && minToken == 0) {
+                return true;
+            }
+            return token > minToken && token <= maxToken;
+        }
+
+        public boolean validateRangePrice() {
+            if(minToken < 0 || maxToken < 0 || minToken >= maxToken) {
+                return false;
+            }
+
+            if(input == null || input.compareTo(BigDecimal.ZERO) <= 0 || output == null || output.compareTo(BigDecimal.ZERO) <= 0) {
+                return false;
+            }
+
+            if(cachedInput != null && cachedInput.compareTo(BigDecimal.ZERO) <= 0) {
+                return false;
+            }
+
+            if(reasoningOutput != null && reasoningOutput.compareTo(BigDecimal.ZERO) <= 0) {
+                return false;
+            }
+
+            return true;
+        }
+    }
+
+    public RangePrice matchRangePrice(int inputToken, int outputToken) {
+        if(tiers == null || tiers.isEmpty()) {
+            throw new IllegalStateException("tiers列表为空，无法匹配价格区间");
+        }
+
+        for (Tier tier : tiers) {
+            RangePrice inputRange = tier.getInputRangePrice();
+            if(!inputRange.match(inputToken)) {
+                continue;
+            }
+
+            List<RangePrice> outputRanges = tier.getOutputRangePrices();
+            if(outputRanges == null || outputRanges.isEmpty()) {
+                return inputRange;
+            }
+
+            for (RangePrice outputRange : outputRanges) {
+                if(outputRange.match(outputToken)) {
+                    return outputRange;
+                }
+            }
+        }
+
+        throw new IllegalStateException("未匹配到任何价格区间，inputToken=" + inputToken + ", outputToken=" + outputToken);
+    }
+
+    public boolean validate() {
+        if(tiers == null || tiers.isEmpty()) {
+            return false;
+        }
+
+        if(!tiers.stream().allMatch(Tier::validateTier)) {
+            return false;
+        }
+
+        List<RangePrice> inputRanges = tiers.stream().map(Tier::getInputRangePrice).collect(Collectors.toList());
+        if(!isValidCoverage(inputRanges)) {
+            return false;
+        }
+
+        return tiers.stream().filter(tier -> tier.getOutputRangePrices() != null && !tier.getOutputRangePrices().isEmpty())
+                .allMatch(tier -> isValidCoverage(tier.getOutputRangePrices()));
+    }
+
+    private boolean isValidCoverage(List<RangePrice> intervals) {
+        if(intervals == null || intervals.isEmpty()) {
+            return false;
+        }
+
+        intervals.sort(Comparator.comparingInt(RangePrice::getMinToken));
+
+        if(intervals.get(0).getMinToken() != 0) {
+            return false;
+        }
+
+        int expectedStart = 0;
+        for (RangePrice interval : intervals) {
+            if(interval.getMinToken() != expectedStart) {
+                return false;
+            }
+            expectedStart = interval.getMaxToken();
+        }
+
+        return expectedStart == Integer.MAX_VALUE;
+    }
+}

--- a/api/server/src/main/java/com/ke/bella/openapi/endpoints/ResponsesController.java
+++ b/api/server/src/main/java/com/ke/bella/openapi/endpoints/ResponsesController.java
@@ -1,0 +1,169 @@
+package com.ke.bella.openapi.endpoints;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import com.ke.bella.openapi.BellaContext;
+import com.ke.bella.openapi.EndpointContext;
+import com.ke.bella.openapi.EndpointProcessData;
+import com.ke.bella.openapi.annotations.EndpointAPI;
+import com.ke.bella.openapi.common.exception.BizParamCheckException;
+import com.ke.bella.openapi.protocol.AdaptorManager;
+import com.ke.bella.openapi.protocol.ChannelRouter;
+import com.ke.bella.openapi.protocol.completion.ResponsesAdaptor;
+import com.ke.bella.openapi.protocol.completion.ResponsesApiProperty;
+import com.ke.bella.openapi.protocol.completion.ResponsesApiRequest;
+import com.ke.bella.openapi.protocol.completion.ResponsesApiResponse;
+import com.ke.bella.openapi.protocol.completion.callback.ResponsesApiSseCallback;
+import com.ke.bella.openapi.protocol.log.EndpointLogger;
+import com.ke.bella.openapi.service.EndpointDataService;
+import com.ke.bella.openapi.tables.pojos.ChannelDB;
+import com.ke.bella.openapi.utils.DateTimeUtils;
+import com.ke.bella.openapi.utils.JacksonUtils;
+import com.ke.bella.openapi.utils.SseHelper;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.extern.slf4j.Slf4j;
+
+@EndpointAPI
+@RestController
+@RequestMapping("/v1/responses")
+@Tag(name = "responses")
+@Slf4j
+public class ResponsesController {
+
+    private static final long SSE_TIMEOUT_MS = 1000L * 60 * 30;
+
+    @Autowired
+    private ChannelRouter router;
+
+    @Autowired
+    private AdaptorManager adaptorManager;
+
+    @Autowired
+    private EndpointDataService endpointDataService;
+
+    @Autowired
+    private EndpointLogger logger;
+
+    @PostMapping
+    public Object createResponse(@org.springframework.web.bind.annotation.RequestBody ResponsesApiRequest request,
+            HttpServletRequest httpRequest) {
+        String endpoint = httpRequest.getRequestURI();
+
+        String model = request.getModel();
+        if(StringUtils.isBlank(model)) {
+            throw new BizParamCheckException("model is required");
+        }
+
+        endpointDataService.setEndpointData(endpoint, model, request);
+
+        String channelCode = getChannelCode();
+
+        ChannelDB channel = routeToChannel(endpoint, model, channelCode);
+        endpointDataService.setChannel(channel);
+
+        EndpointProcessData processData = EndpointContext.getProcessData();
+        String protocol = processData.getProtocol();
+        String url = processData.getForwardUrl();
+        String channelInfo = channel.getChannelInfo();
+
+        ResponsesAdaptor responsesAdaptor = adaptorManager.getProtocolAdaptor(endpoint, protocol, ResponsesAdaptor.class);
+        if(responsesAdaptor == null) {
+            throw new BizParamCheckException("Unsupported protocol: " + protocol);
+        }
+
+        @SuppressWarnings("unchecked")
+        ResponsesApiProperty property = (ResponsesApiProperty) JacksonUtils.deserialize(channelInfo, responsesAdaptor.getPropertyClass());
+        EndpointContext.setEncodingType(property.getEncodingType());
+
+        if(Boolean.TRUE.equals(request.getStream())) {
+            SseEmitter sse = SseHelper.createSse(SSE_TIMEOUT_MS, processData.getRequestId());
+            ResponsesApiSseCallback callback = new ResponsesApiSseCallback(
+                    sse, processData, EndpointContext.getApikey(), logger);
+            @SuppressWarnings("unchecked")
+            ResponsesAdaptor<ResponsesApiProperty> adaptor = responsesAdaptor;
+            adaptor.streamResponseAsync(request, url, property, callback);
+            return sse;
+        }
+
+        @SuppressWarnings("unchecked")
+        ResponsesAdaptor<ResponsesApiProperty> adaptor = responsesAdaptor;
+        ResponsesApiResponse response = adaptor.createResponse(request, url, property);
+
+        response.set_bella_response(ResponsesApiResponse.BellaResponse.builder()
+                .channel_code(channel.getChannelCode())
+                .build());
+        response.setCreated(DateTimeUtils.getCurrentSeconds());
+
+        return response;
+    }
+
+    @GetMapping("/{response_id}")
+    public ResponsesApiResponse getResponse(
+            @PathVariable("response_id") String responseId) {
+
+        if(StringUtils.isBlank(responseId)) {
+            throw new BizParamCheckException("response_id is required");
+        }
+
+        String channelCode = getChannelCode();
+
+        if(StringUtils.isBlank(channelCode)) {
+            throw new BizParamCheckException("channel_code is required for query");
+        }
+
+        ChannelDB channel = router.route(channelCode);
+
+        EndpointProcessData processData = EndpointContext.getProcessData();
+        processData.setChannelCode(channel.getChannelCode());
+        processData.setProtocol(channel.getProtocol());
+        processData.setForwardUrl(channel.getUrl());
+
+        String endpoint = "/v1/responses";
+        String protocol = channel.getProtocol();
+        String url = channel.getUrl();
+        String channelInfo = channel.getChannelInfo();
+
+        ResponsesAdaptor responsesAdaptor = adaptorManager.getProtocolAdaptor(endpoint, protocol, ResponsesAdaptor.class);
+        if(responsesAdaptor == null) {
+            throw new BizParamCheckException("Unsupported protocol: " + protocol);
+        }
+
+        ResponsesApiProperty property = (ResponsesApiProperty) JacksonUtils.deserialize(channelInfo, responsesAdaptor.getPropertyClass());
+
+        ResponsesAdaptor<ResponsesApiProperty> adaptor = responsesAdaptor;
+        ResponsesApiResponse response = adaptor.getResponse(responseId, url, property);
+
+        response.set_bella_response(ResponsesApiResponse.BellaResponse.builder()
+                .channel_code(channel.getChannelCode())
+                .build());
+
+        return response;
+    }
+
+    private String getChannelCode() {
+        return BellaContext.getHeaders().get("X-BELLA-CHANNEL");
+    }
+
+    private ChannelDB routeToChannel(String endpoint, String model, String channelCode) {
+        if(StringUtils.isNotBlank(channelCode)) {
+            ChannelDB channel = router.route(channelCode);
+            if(channel == null) {
+                throw new BizParamCheckException("channel_code not found: " + channelCode);
+            }
+            return channel;
+        }
+
+        return router.route(endpoint, model, EndpointContext.getApikey(), false);
+    }
+
+}

--- a/api/server/src/main/java/com/ke/bella/openapi/protocol/completion/OpenAIResponsesAdaptor.java
+++ b/api/server/src/main/java/com/ke/bella/openapi/protocol/completion/OpenAIResponsesAdaptor.java
@@ -1,0 +1,233 @@
+package com.ke.bella.openapi.protocol.completion;
+
+import org.apache.commons.collections4.MapUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.stereotype.Component;
+
+import com.ke.bella.openapi.common.exception.ChannelException;
+import com.ke.bella.openapi.protocol.BellaEventSourceListener;
+import com.ke.bella.openapi.protocol.Callbacks;
+import com.ke.bella.openapi.utils.HttpUtils;
+import com.ke.bella.openapi.utils.JacksonUtils;
+
+import lombok.extern.slf4j.Slf4j;
+import okhttp3.MediaType;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import okhttp3.sse.EventSource;
+
+/**
+ * OpenAI Responses API 原生协议适配器
+ * 用于 /v1/responses 端点
+ * 支持同步、后台异步、流式和查询四种模式
+ */
+@Component("OpenAIResponses")
+@Slf4j
+public class OpenAIResponsesAdaptor implements ResponsesAdaptor<ResponsesApiProperty> {
+
+    private static final int CONNECTION_TIMEOUT = 30;
+    private static final int READ_TIMEOUT = 1800;
+
+    @Override
+    public String getDescription() {
+        return "OpenAI Responses API原生协议";
+    }
+
+    @Override
+    public Class<ResponsesApiProperty> getPropertyClass() {
+        return ResponsesApiProperty.class;
+    }
+
+    /**
+     * 创建 Response（同步或后台异步取决于 request.background）
+     *
+     * @param request  ResponsesApiRequest 原生请求（通过 request.background 控制模式）
+     * @param url      目标URL
+     * @param property 配置属性
+     *
+     * @return ResponsesApiResponse 原生响应
+     */
+    @Override
+    public ResponsesApiResponse createResponse(ResponsesApiRequest request, String url, ResponsesApiProperty property) {
+        log.debug("Creating Responses API request, background={}", request.getBackground());
+
+        request.setModel(property.getDeployName());
+        request.setStream(false);
+
+        if(StringUtils.isNotEmpty(property.getApiVersion())) {
+            url += property.getApiVersion();
+        }
+
+        Request httpRequest = buildRequest(request, url, property);
+
+        ResponsesApiResponse response = HttpUtils.httpRequest(httpRequest, ResponsesApiResponse.class,
+                (errorResponse, res) -> {
+                    if(errorResponse.getError() != null) {
+                        errorResponse.getError().setHttpCode(res.code());
+                    }
+                }, CONNECTION_TIMEOUT, READ_TIMEOUT);
+
+        log.debug("Responses API request completed: {}, status: {}", response.getId(), response.getStatus());
+        return response;
+    }
+
+    /**
+     * 查询 Response 状态
+     *
+     * @param responseId Response ID
+     * @param url        目标URL（不含 response_id）
+     * @param property   配置属性
+     *
+     * @return ResponsesApiResponse 原生响应
+     */
+    @Override
+    public ResponsesApiResponse getResponse(String responseId, String url, ResponsesApiProperty property) {
+        log.debug("Querying Responses API status for: {}", responseId);
+
+        String queryUrl = url;
+        if(StringUtils.isNotEmpty(property.getApiVersion())) {
+            queryUrl += property.getApiVersion();
+        }
+        queryUrl += "/" + responseId;
+
+        Request.Builder builder = authorizationRequestBuilder(property.getAuth())
+                .url(queryUrl)
+                .get();
+
+        if(MapUtils.isNotEmpty(property.getExtraHeaders())) {
+            property.getExtraHeaders().forEach(builder::addHeader);
+        }
+
+        Request httpRequest = builder.build();
+
+        ResponsesApiResponse response = HttpUtils.httpRequest(httpRequest, ResponsesApiResponse.class,
+                (errorResponse, res) -> {
+                    if(errorResponse.getError() != null) {
+                        errorResponse.getError().setHttpCode(res.code());
+                    }
+                }, CONNECTION_TIMEOUT, READ_TIMEOUT);
+
+        log.debug("Responses API query completed: {}, status: {}", response.getId(), response.getStatus());
+        return response;
+    }
+
+    /**
+     * 创建流式 Response（原生 SSE 格式）
+     *
+     * @param request  ResponsesApiRequest 原生请求
+     * @param url      目标URL
+     * @param property 配置属性
+     * @param callback 原生 SSE 回调
+     */
+    @Override
+    public void streamResponseAsync(ResponsesApiRequest request, String url, ResponsesApiProperty property,
+            Callbacks.ResponsesApiSseCallback callback) {
+        log.debug("Creating streaming Responses API request");
+
+        request.setModel(property.getDeployName());
+        request.setStream(true);
+
+        if(request.getStore() == null) {
+            request.setStore(false);
+        }
+
+        if(StringUtils.isNotEmpty(property.getApiVersion())) {
+            url += property.getApiVersion();
+        }
+
+        Request httpRequest = buildRequest(request, url, property);
+
+        BellaEventSourceListener listener = new BellaEventSourceListener() {
+            @Override
+            public void onEvent(EventSource eventSource, String id, String type, String data) {
+                try {
+                    if(StringUtils.isNotBlank(data)) {
+                        callback.onEvent(id, type, data);
+                    }
+                } catch (Exception e) {
+                    log.error("Error processing SSE event: type={}, data={}", type, data, e);
+                    callback.onError(ChannelException.fromException(e));
+                    eventSource.cancel();
+                }
+            }
+
+            @Override
+            public void onClosed(EventSource eventSource) {
+                log.debug("Streaming Responses API connection closed");
+                callback.onComplete();
+            }
+
+            @Override
+            public void onFailure(EventSource eventSource, Throwable t, Response response) {
+                ChannelException exception;
+                try {
+                    if(t == null) {
+                        exception = convertToException(response);
+                    } else {
+                        if(t instanceof ChannelException) {
+                            exception = (ChannelException) t;
+                        } else {
+                            exception = ChannelException.fromException(t);
+                        }
+                    }
+                } catch (Exception e) {
+                    log.error("Error converting failure to exception", e);
+                    exception = ChannelException.fromException(e);
+                }
+
+                if(connectionInitFuture != null && connectionInitFuture.isDone()) {
+                    callback.onError(exception);
+                } else if(connectionInitFuture != null) {
+                    connectionInitFuture.completeExceptionally(exception);
+                } else {
+                    callback.onError(exception);
+                }
+            }
+        };
+
+        HttpUtils.streamRequest(httpRequest, listener, CONNECTION_TIMEOUT, READ_TIMEOUT);
+    }
+
+    /**
+     * 将 HTTP 错误响应转换为 ChannelException
+     */
+    private ChannelException convertToException(Response response) {
+        try {
+            if(response.body() == null) {
+                return ChannelException.fromResponse(response.code(), response.message());
+            }
+            String msg = response.body().string();
+            ResponsesApiResponse errorResponse = JacksonUtils.deserialize(msg, ResponsesApiResponse.class);
+            if(errorResponse != null && errorResponse.getError() != null) {
+                return new ChannelException.OpenAIException(
+                        response.code(),
+                        errorResponse.getError().getType(),
+                        errorResponse.getError().getMessage(),
+                        errorResponse.getError());
+            } else {
+                return ChannelException.fromResponse(response.code(), msg);
+            }
+        } catch (Exception e) {
+            log.warn("Failed to parse error response", e);
+            return ChannelException.fromResponse(response.code(), response.message());
+        } finally {
+            response.close();
+        }
+    }
+
+    /**
+     * 构建 HTTP POST 请求
+     */
+    private Request buildRequest(ResponsesApiRequest request, String url, ResponsesApiProperty property) {
+        Request.Builder builder = authorizationRequestBuilder(property.getAuth())
+                .url(url)
+                .post(RequestBody.create(MediaType.parse("application/json"), JacksonUtils.toByte(request)));
+
+        if(MapUtils.isNotEmpty(property.getExtraHeaders())) {
+            property.getExtraHeaders().forEach(builder::addHeader);
+        }
+
+        return builder.build();
+    }
+}

--- a/api/server/src/main/java/com/ke/bella/openapi/protocol/completion/ResponsesAdaptor.java
+++ b/api/server/src/main/java/com/ke/bella/openapi/protocol/completion/ResponsesAdaptor.java
@@ -1,0 +1,47 @@
+package com.ke.bella.openapi.protocol.completion;
+
+import com.ke.bella.openapi.protocol.Callbacks;
+import com.ke.bella.openapi.protocol.IProtocolAdaptor;
+
+public interface ResponsesAdaptor<T extends ResponsesApiProperty> extends IProtocolAdaptor {
+
+    /**
+     * 创建 Response（同步或后台异步取决于 request.background）
+     *
+     * @param request  ResponsesApiRequest 原生请求（通过 request.background 控制模式）
+     * @param url      目标URL
+     * @param property 配置属性
+     *
+     * @return ResponsesApiResponse 原生响应
+     *         - background=false: 返回 status=completed
+     *         - background=true: 返回 status=pending
+     */
+    ResponsesApiResponse createResponse(ResponsesApiRequest request, String url, T property);
+
+    /**
+     * 创建流式 Response（原生 SSE 格式）
+     *
+     * @param request  ResponsesApiRequest 原生请求
+     * @param url      目标URL
+     * @param property 配置属性
+     * @param callback 原生 SSE 回调
+     */
+    void streamResponseAsync(ResponsesApiRequest request, String url, T property,
+            Callbacks.ResponsesApiSseCallback callback);
+
+    /**
+     * 查询 Response 状态
+     *
+     * @param responseId Response ID
+     * @param url        目标URL（不含 response_id）
+     * @param property   配置属性
+     *
+     * @return ResponsesApiResponse 原生响应
+     */
+    ResponsesApiResponse getResponse(String responseId, String url, T property);
+
+    @Override
+    default String endpoint() {
+        return "/v1/responses";
+    }
+}

--- a/api/server/src/main/java/com/ke/bella/openapi/protocol/completion/ResponsesLogHandler.java
+++ b/api/server/src/main/java/com/ke/bella/openapi/protocol/completion/ResponsesLogHandler.java
@@ -1,0 +1,74 @@
+package com.ke.bella.openapi.protocol.completion;
+
+import com.google.common.collect.ImmutableMap;
+import com.ke.bella.openapi.EndpointProcessData;
+import com.ke.bella.openapi.protocol.log.EndpointLogHandler;
+import com.ke.bella.openapi.utils.DateTimeUtils;
+import com.ke.bella.openapi.utils.JacksonUtils;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+@Slf4j
+@Component
+public class ResponsesLogHandler implements EndpointLogHandler {
+
+    @Override
+    public void process(EndpointProcessData processData) {
+        long startTime = processData.getRequestTime();
+        ResponsesApiResponse response = null;
+
+        if(processData.getResponse() instanceof ResponsesApiResponse) {
+            response = (ResponsesApiResponse) processData.getResponse();
+        }
+
+        if(StringUtils.isNotBlank(processData.getResponseRaw()) && processData.getResponse() == null) {
+            response = JacksonUtils.deserialize(processData.getResponseRaw(), ResponsesApiResponse.class);
+        }
+
+        if(StringUtils.isNotBlank(processData.getRequestRaw())) {
+            ResponsesApiRequest request = JacksonUtils.deserialize(processData.getRequestRaw(), ResponsesApiRequest.class);
+            processData.setRequest(request);
+        }
+
+        long created = response == null || response.getCreated() <= 0
+                ? DateTimeUtils.getCurrentSeconds()
+                : response.getCreated();
+        long firstPackageTime = processData.getFirstPackageTime();
+
+        ResponsesApiResponse.Usage usage;
+        if(response == null || response.getUsage() == null) {
+            log.warn("No response usage for requestId: {}, endpoint: {}",
+                    processData.getRequestId(), processData.getEndpoint());
+            usage = new ResponsesApiResponse.Usage();
+            usage.setInput_tokens(0);
+            usage.setOutput_tokens(0);
+            usage.setTotal_tokens(0);
+        } else {
+            usage = response.getUsage();
+        }
+
+        processData.setUsage(usage);
+        processData.setMetrics(countMetrics(startTime, processData.getRequestMillis(), created, firstPackageTime, usage));
+    }
+
+    @Override
+    public String endpoint() {
+        return "/v1/responses";
+    }
+
+
+    private Map<String, Object> countMetrics(long startTime, long startMills, long endTime, long firstPackageTime,
+            ResponsesApiResponse.Usage usage) {
+        int inputToken = usage.getInput_tokens() != null ? usage.getInput_tokens() : 0;
+        int outputToken = usage.getOutput_tokens() != null ? usage.getOutput_tokens() : 0;
+        int ttft = 0;
+        if(firstPackageTime != 0) {
+            ttft = (int) (firstPackageTime - startMills);
+        }
+        int ttlt = (int) (endTime - startTime);
+        return ImmutableMap.of("ttft", ttft, "ttlt", ttlt, "input_token", inputToken, "output_token", outputToken);
+    }
+}

--- a/api/server/src/main/java/com/ke/bella/openapi/protocol/completion/callback/ResponsesApiSseCallback.java
+++ b/api/server/src/main/java/com/ke/bella/openapi/protocol/completion/callback/ResponsesApiSseCallback.java
@@ -1,0 +1,181 @@
+package com.ke.bella.openapi.protocol.completion.callback;
+
+import java.io.IOException;
+
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import com.ke.bella.openapi.EndpointProcessData;
+import com.ke.bella.openapi.apikey.ApikeyInfo;
+import com.ke.bella.openapi.common.exception.ChannelException;
+import com.ke.bella.openapi.protocol.Callbacks;
+import com.ke.bella.openapi.protocol.completion.ResponsesApiResponse;
+import com.ke.bella.openapi.protocol.completion.ResponsesApiStreamEvent;
+import com.ke.bella.openapi.protocol.log.EndpointLogger;
+import com.ke.bella.openapi.utils.DateTimeUtils;
+import com.ke.bella.openapi.utils.JacksonUtils;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class ResponsesApiSseCallback implements Callbacks.ResponsesApiSseCallback {
+    protected final SseEmitter sse;
+    protected final EndpointProcessData processData;
+    protected final ApikeyInfo apikeyInfo;
+    protected final EndpointLogger logger;
+    protected Long firstPackageTime;
+    protected ResponsesApiResponse.Usage usage;
+    protected String responseId;
+    protected boolean completed = false;
+
+    public ResponsesApiSseCallback(SseEmitter sse, EndpointProcessData processData,
+            ApikeyInfo apikeyInfo, EndpointLogger logger) {
+        this.sse = sse;
+        this.processData = processData;
+        this.apikeyInfo = apikeyInfo;
+        this.logger = logger;
+    }
+
+    @Override
+    public void onEvent(String eventId, String eventType, String eventData) {
+        if(completed) {
+            return;
+        }
+
+        if(firstPackageTime == null && isFirstDataEvent(eventType)) {
+            firstPackageTime = DateTimeUtils.getCurrentMills();
+            log.debug("First package received at: {}, eventType: {}", firstPackageTime, eventType);
+        }
+
+        if("response.completed".equals(eventType)) {
+            extractUsageAndMetadata(eventData);
+        }
+
+        sendSseEvent(eventType, eventData);
+    }
+
+    @Override
+    public void onComplete() {
+        if(completed) {
+            return;
+        }
+        completed = true;
+
+        if(sse != null) {
+            sse.complete();
+        }
+        log();
+    }
+
+    @Override
+    public void onError(ChannelException exception) {
+        if(completed) {
+            return;
+        }
+        completed = true;
+
+        log.error("Responses API SSE error: {}", exception.getMessage(), exception);
+
+        if(sse != null) {
+            try {
+                ResponsesApiResponse errorResponse = new ResponsesApiResponse();
+                errorResponse.setError(exception.convertToOpenapiError());
+
+                SseEmitter.SseEventBuilder errorEvent = SseEmitter.event()
+                        .name(" " + "response.error")
+                        .data(" " + JacksonUtils.serialize(errorResponse));
+                sse.send(errorEvent);
+                sse.completeWithError(exception);
+            } catch (IOException e) {
+                log.error("Failed to send error event", e);
+            }
+        }
+        log();
+    }
+
+    private boolean isFirstDataEvent(String eventType) {
+        return "response.created".equals(eventType);
+    }
+
+    private void extractUsageAndMetadata(String eventData) {
+        try {
+            // TODO: Remove debug logs after usage issue is resolved
+            log.info("[DEBUG-USAGE] Extracting usage from response.completed event, eventData length: {}",
+                    eventData != null ? eventData.length() : 0);
+
+            ResponsesApiStreamEvent event = JacksonUtils.deserialize(eventData, ResponsesApiStreamEvent.class);
+            if(event == null) {
+                log.info("[DEBUG-USAGE] Failed to parse ResponsesApiStreamEvent from eventData");
+                return;
+            }
+
+            if(event.getResponse() == null) {
+                log.info("[DEBUG-USAGE] ResponsesApiStreamEvent.response is null");
+                return;
+            }
+
+            ResponsesApiResponse response = event.getResponse();
+
+            if(StringUtils.isNotBlank(response.getId())) {
+                this.responseId = response.getId();
+                log.info("[DEBUG-USAGE] Extracted response_id: {}", this.responseId);
+            }
+
+            if(response.getUsage() != null) {
+                this.usage = response.getUsage();
+                log.info("[DEBUG-USAGE] Extracted usage from response.completed: input={}, output={}, total={}",
+                        usage.getInput_tokens(), usage.getOutput_tokens(), usage.getTotal_tokens());
+            } else {
+                log.info("[DEBUG-USAGE] Usage is null in response.completed event");
+            }
+        } catch (Exception e) {
+            log.error("[DEBUG-USAGE] Failed to extract usage from response.completed event, eventData: {}", eventData, e);
+        }
+    }
+
+    private void sendSseEvent(String eventType, String eventData) {
+        if(sse == null) {
+            return;
+        }
+
+        try {
+            SseEmitter.SseEventBuilder event = SseEmitter.event();
+            if(StringUtils.isNotBlank(eventType)) {
+                event.name(" " + eventType);
+            }
+            event.data(" " + eventData);
+            sse.send(event);
+        } catch (IOException e) {
+            log.error("Failed to send SSE event: {}", eventType, e);
+            throw new RuntimeException("Failed to send SSE event", e);
+        }
+    }
+
+    private void log() {
+        long endTime = DateTimeUtils.getCurrentSeconds();
+        processData.setDuration(endTime - processData.getRequestTime());
+        processData.setFirstPackageTime(firstPackageTime == null ? DateTimeUtils.getCurrentMills() : firstPackageTime);
+
+        // TODO: Remove debug logs after usage issue is resolved
+        if(usage != null) {
+            // Build response object for ResponsesLogHandler
+            ResponsesApiResponse response = ResponsesApiResponse.builder()
+                    .id(responseId)
+                    .created(endTime)
+                    .usage(usage)
+                    .build();
+            processData.setResponse(response);
+
+            log.info("[DEBUG-USAGE] Setting response with usage to processData: input={}, output={}, total={}",
+                    usage.getInput_tokens(), usage.getOutput_tokens(), usage.getTotal_tokens());
+        } else {
+            log.info("[DEBUG-USAGE] Usage is null in log() method, streaming request may not have received response.completed event");
+        }
+
+        if(StringUtils.isNotBlank(responseId)) {
+            processData.setChannelRequestId(responseId);
+        }
+
+        logger.log(processData);
+    }
+}

--- a/api/server/src/main/java/com/ke/bella/openapi/protocol/cost/CostCalculator.java
+++ b/api/server/src/main/java/com/ke/bella/openapi/protocol/cost/CostCalculator.java
@@ -2,6 +2,7 @@ package com.ke.bella.openapi.protocol.cost;
 
 import java.math.BigDecimal;
 import java.util.Arrays;
+import java.util.Map;
 import java.util.Optional;
 
 import org.apache.commons.collections4.CollectionUtils;
@@ -14,6 +15,8 @@ import com.ke.bella.openapi.protocol.asr.flash.FlashAsrPriceInfo;
 import com.ke.bella.openapi.protocol.asr.transcription.TranscriptionsAsrPriceInfo;
 import com.ke.bella.openapi.protocol.completion.CompletionPriceInfo;
 import com.ke.bella.openapi.protocol.completion.CompletionResponse;
+import com.ke.bella.openapi.protocol.completion.ResponsesApiResponse;
+import com.ke.bella.openapi.protocol.completion.ResponsesPriceInfo;
 import com.ke.bella.openapi.protocol.embedding.EmbeddingPriceInfo;
 import com.ke.bella.openapi.protocol.embedding.EmbeddingResponse;
 import com.ke.bella.openapi.protocol.images.ImagesEditsPriceInfo;
@@ -67,6 +70,7 @@ public class CostCalculator {
     enum CostCalculators {
         COMPLETION("/v*/chat/completions", completion),
         MESSAGES("/v*/messages", completion),
+        RESPONSES("/v*/responses", responses),
         GEMINI("/v1beta/models", completion),
         EMBEDDING("/v*/embeddings", embedding),
         TTS("/v*/audio/speech", tts),
@@ -478,6 +482,122 @@ public class CostCalculator {
         public boolean checkPriceInfo(String priceInfo) {
             VideoPriceInfo price = JacksonUtils.deserialize(priceInfo, VideoPriceInfo.class);
             return price != null && price.getOutput() != null;
+        }
+    };
+
+    static EndpointCostCalculator responses = new EndpointCostCalculator() {
+        @Override
+        public BigDecimal calculate(String priceInfo, Object usage) {
+            ResponsesPriceInfo price = JacksonUtils.deserialize(priceInfo, ResponsesPriceInfo.class);
+
+            ResponsesApiResponse.Usage responsesUsage = null;
+            CompletionResponse.TokenUsage tokenUsage = null;
+
+            if(usage instanceof ResponsesApiResponse.Usage) {
+                responsesUsage = (ResponsesApiResponse.Usage) usage;
+            } else if(usage instanceof CompletionResponse.TokenUsage) {
+                tokenUsage = (CompletionResponse.TokenUsage) usage;
+            } else {
+                String usageJson = JacksonUtils.serialize(usage);
+                responsesUsage = JacksonUtils.deserialize(usageJson, ResponsesApiResponse.Usage.class);
+            }
+
+            int inputTokens = 0;
+            int outputTokens = 0;
+            BigDecimal cost = BigDecimal.ZERO;
+
+            if(responsesUsage != null) {
+                inputTokens = responsesUsage.getInput_tokens() != null ? responsesUsage.getInput_tokens() : 0;
+                outputTokens = responsesUsage.getOutput_tokens() != null ? responsesUsage.getOutput_tokens() : 0;
+
+                ResponsesPriceInfo.RangePrice rangePrice = price.matchRangePrice(inputTokens, outputTokens);
+
+                if(responsesUsage.getInput_tokens_details() != null
+                        && responsesUsage.getInput_tokens_details().getCached_tokens() != null) {
+                    int cachedTokens = responsesUsage.getInput_tokens_details().getCached_tokens();
+                    if(cachedTokens > 0 && rangePrice.getCachedInput() != null) {
+                        cost = cost.add(rangePrice.getCachedInput().multiply(BigDecimal.valueOf(cachedTokens / 1000.0)));
+                        inputTokens -= cachedTokens;
+                    }
+                }
+
+                if(responsesUsage.getOutput_tokens_details() != null
+                        && responsesUsage.getOutput_tokens_details().getReasoning_tokens() != null) {
+                    int reasoningTokens = responsesUsage.getOutput_tokens_details().getReasoning_tokens();
+                    if(reasoningTokens > 0 && rangePrice.getReasoningOutput() != null) {
+                        cost = cost.add(rangePrice.getReasoningOutput().multiply(BigDecimal.valueOf(reasoningTokens / 1000.0)));
+                        outputTokens -= reasoningTokens;
+                    }
+                }
+
+                cost = cost.add(rangePrice.getInput().multiply(BigDecimal.valueOf(inputTokens / 1000.0)))
+                        .add(rangePrice.getOutput().multiply(BigDecimal.valueOf(outputTokens / 1000.0)));
+
+                if(price.getToolPrices() != null && responsesUsage.getTool_usage() != null) {
+                    cost = cost.add(calculateToolCost(price.getToolPrices(), responsesUsage.getTool_usage()));
+                }
+            } else if(tokenUsage != null) {
+                inputTokens = tokenUsage.getPrompt_tokens();
+                outputTokens = tokenUsage.getCompletion_tokens();
+
+                ResponsesPriceInfo.RangePrice rangePrice = price.matchRangePrice(inputTokens, outputTokens);
+
+                if(tokenUsage.getPrompt_tokens_details() != null) {
+                    int cachedTokens = tokenUsage.getPrompt_tokens_details().getCached_tokens();
+                    if(cachedTokens > 0 && rangePrice.getCachedInput() != null) {
+                        cost = cost.add(rangePrice.getCachedInput().multiply(BigDecimal.valueOf(cachedTokens / 1000.0)));
+                        inputTokens -= cachedTokens;
+                    }
+                }
+
+                if(tokenUsage.getCompletion_tokens_details() != null) {
+                    int reasoningTokens = tokenUsage.getCompletion_tokens_details().getReasoning_tokens();
+                    if(reasoningTokens > 0 && rangePrice.getReasoningOutput() != null) {
+                        cost = cost.add(rangePrice.getReasoningOutput().multiply(BigDecimal.valueOf(reasoningTokens / 1000.0)));
+                        outputTokens -= reasoningTokens;
+                    }
+                }
+
+                cost = cost.add(rangePrice.getInput().multiply(BigDecimal.valueOf(inputTokens / 1000.0)))
+                        .add(rangePrice.getOutput().multiply(BigDecimal.valueOf(outputTokens / 1000.0)));
+            }
+
+            return cost;
+        }
+
+        private BigDecimal calculateToolCost(
+                Map<String, BigDecimal> toolPrices,
+                Map<String, Integer> toolUsage) {
+            BigDecimal toolCost = BigDecimal.ZERO;
+
+            if(toolUsage == null || toolUsage.isEmpty()) {
+                return toolCost;
+            }
+
+            for(Map.Entry<String, Integer> entry : toolUsage.entrySet()) {
+                String toolName = entry.getKey();
+                Integer count = entry.getValue();
+
+                if(count == null || count == 0) {
+                    continue;
+                }
+
+                BigDecimal unitPrice = toolPrices.get(toolName);
+                if(unitPrice != null) {
+                    toolCost = toolCost.add(unitPrice.multiply(BigDecimal.valueOf(count)));
+                }
+            }
+
+            return toolCost;
+        }
+
+        @Override
+        public boolean checkPriceInfo(String priceInfo) {
+            ResponsesPriceInfo price = JacksonUtils.deserialize(priceInfo, ResponsesPriceInfo.class);
+            if(price == null) {
+                return false;
+            }
+            return price.validate();
         }
     };
 

--- a/api/server/src/test/java/com/ke/bella/openapi/protocol/completion/ResponsesToolCostCalculationTest.java
+++ b/api/server/src/test/java/com/ke/bella/openapi/protocol/completion/ResponsesToolCostCalculationTest.java
@@ -1,0 +1,237 @@
+package com.ke.bella.openapi.protocol.completion;
+
+import com.ke.bella.openapi.protocol.cost.CostCalculator;
+import com.ke.bella.openapi.utils.JacksonUtils;
+import org.junit.Test;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * Responses API 工具计费测试
+ * 测试 Doubao 等厂商的工具调用计费场景
+ */
+public class ResponsesToolCostCalculationTest {
+
+    /**
+     * 测试场景：Doubao web_search 工具计费
+     *
+     * Usage:
+     * {
+     *   "input_tokens": 4601,
+     *   "output_tokens": 1244,
+     *   "total_tokens": 5845,
+     *   "input_tokens_details": {"cached_tokens": 0},
+     *   "output_tokens_details": {"reasoning_tokens": 573},
+     *   "tool_usage": {"web_search": 1}
+     * }
+     *
+     * Price:
+     * - input: 1.0 分/千token
+     * - output: 3.0 分/千token
+     * - web_search: 0.5 分/次
+     *
+     * 期望成本（单位：分）:
+     * - Token成本: (4601/1000) * 1.0 + (1244/1000) * 3.0 = 4.601 + 3.732 = 8.333 分
+     * - 工具成本: 1 * 0.5 = 0.5 分
+     * - 总成本: 8.333 + 0.5 = 8.833 分
+     */
+    @Test
+    public void testDoubaoWebSearchToolCost() {
+        ResponsesPriceInfo.RangePrice rangePrice = new ResponsesPriceInfo.RangePrice();
+        rangePrice.setMinToken(0);
+        rangePrice.setMaxToken(Integer.MAX_VALUE);
+        rangePrice.setInput(new BigDecimal("1.0"));
+        rangePrice.setOutput(new BigDecimal("3.0"));
+
+        ResponsesPriceInfo.Tier tier = new ResponsesPriceInfo.Tier();
+        tier.setInputRangePrice(rangePrice);
+
+        List<ResponsesPriceInfo.Tier> tiers = new ArrayList<>();
+        tiers.add(tier);
+
+        ResponsesPriceInfo priceInfo = new ResponsesPriceInfo();
+        priceInfo.setTiers(tiers);
+
+        Map<String, BigDecimal> toolPrices = new HashMap<>();
+        toolPrices.put("web_search", new BigDecimal("0.5"));
+        priceInfo.setToolPrices(toolPrices);
+
+        String priceInfoJson = JacksonUtils.serialize(priceInfo);
+        System.out.println("Price Info JSON: " + priceInfoJson);
+
+        ResponsesApiResponse.Usage usage = new ResponsesApiResponse.Usage();
+        usage.setInput_tokens(4601);
+        usage.setOutput_tokens(1244);
+        usage.setTotal_tokens(5845);
+
+        ResponsesApiResponse.InputTokensDetail inputDetail = new ResponsesApiResponse.InputTokensDetail();
+        inputDetail.setCached_tokens(0);
+        usage.setInput_tokens_details(inputDetail);
+
+        ResponsesApiResponse.OutputTokensDetail outputDetail = new ResponsesApiResponse.OutputTokensDetail();
+        outputDetail.setReasoning_tokens(573);
+        usage.setOutput_tokens_details(outputDetail);
+
+        Map<String, Integer> toolUsage = new HashMap<>();
+        toolUsage.put("web_search", 1);
+        usage.setTool_usage(toolUsage);
+
+        BigDecimal cost = CostCalculator.calculate("/v1/responses", priceInfoJson, usage);
+
+        assertNotNull("Cost should not be null", cost);
+
+        BigDecimal expectedTokenCost = new BigDecimal("4.601").add(new BigDecimal("3.732"));
+        System.out.println("Expected Token Cost: " + expectedTokenCost);
+
+        BigDecimal expectedToolCost = new BigDecimal("0.5");
+        System.out.println("Expected Tool Cost: " + expectedToolCost);
+
+        BigDecimal expectedTotalCost = expectedTokenCost.add(expectedToolCost);
+        System.out.println("Expected Total Cost: " + expectedTotalCost);
+        System.out.println("Actual Cost: " + cost);
+
+        assertEquals("Cost calculation should be accurate",
+                expectedTotalCost.doubleValue(), cost.doubleValue(), 0.001);
+    }
+
+    /**
+     * 测试场景2：code_interpreter 工具计费
+     */
+    @Test
+    public void testCodeInterpreterToolCost() {
+        ResponsesPriceInfo.RangePrice rangePrice = new ResponsesPriceInfo.RangePrice();
+        rangePrice.setMinToken(0);
+        rangePrice.setMaxToken(Integer.MAX_VALUE);
+        rangePrice.setInput(new BigDecimal("1.0"));
+        rangePrice.setOutput(new BigDecimal("3.0"));
+
+        ResponsesPriceInfo.Tier tier = new ResponsesPriceInfo.Tier();
+        tier.setInputRangePrice(rangePrice);
+
+        List<ResponsesPriceInfo.Tier> tiers = new ArrayList<>();
+        tiers.add(tier);
+
+        ResponsesPriceInfo priceInfo = new ResponsesPriceInfo();
+        priceInfo.setTiers(tiers);
+
+        Map<String, BigDecimal> toolPrices = new HashMap<>();
+        toolPrices.put("code_interpreter", new BigDecimal("1.0"));
+        priceInfo.setToolPrices(toolPrices);
+
+        String priceInfoJson = JacksonUtils.serialize(priceInfo);
+
+        ResponsesApiResponse.Usage usage = new ResponsesApiResponse.Usage();
+        usage.setInput_tokens(1000);
+        usage.setOutput_tokens(500);
+
+        Map<String, Integer> toolUsage = new HashMap<>();
+        toolUsage.put("code_interpreter", 2);
+        usage.setTool_usage(toolUsage);
+
+        BigDecimal cost = CostCalculator.calculate("/v1/responses", priceInfoJson, usage);
+
+        assertNotNull("Cost should not be null", cost);
+
+        BigDecimal expectedTokenCost = new BigDecimal("1.0").add(new BigDecimal("1.5"));
+        BigDecimal expectedToolCost = new BigDecimal("1.0").multiply(new BigDecimal("2"));
+        BigDecimal expectedTotalCost = expectedTokenCost.add(expectedToolCost);
+
+        System.out.println("Code Interpreter Test - Expected: " + expectedTotalCost + ", Actual: " + cost);
+
+        assertEquals("Cost with code_interpreter should be accurate",
+                expectedTotalCost.doubleValue(), cost.doubleValue(), 0.001);
+    }
+
+    /**
+     * 测试场景3：多次工具调用计费
+     */
+    @Test
+    public void testMultipleToolCalls() {
+        ResponsesPriceInfo.RangePrice rangePrice = new ResponsesPriceInfo.RangePrice();
+        rangePrice.setMinToken(0);
+        rangePrice.setMaxToken(Integer.MAX_VALUE);
+        rangePrice.setInput(new BigDecimal("1.0"));
+        rangePrice.setOutput(new BigDecimal("3.0"));
+
+        ResponsesPriceInfo.Tier tier = new ResponsesPriceInfo.Tier();
+        tier.setInputRangePrice(rangePrice);
+
+        List<ResponsesPriceInfo.Tier> tiers = new ArrayList<>();
+        tiers.add(tier);
+
+        ResponsesPriceInfo priceInfo = new ResponsesPriceInfo();
+        priceInfo.setTiers(tiers);
+
+        Map<String, BigDecimal> toolPrices = new HashMap<>();
+        toolPrices.put("web_search", new BigDecimal("0.5"));
+        priceInfo.setToolPrices(toolPrices);
+
+        String priceInfoJson = JacksonUtils.serialize(priceInfo);
+
+        ResponsesApiResponse.Usage usage = new ResponsesApiResponse.Usage();
+        usage.setInput_tokens(2000);
+        usage.setOutput_tokens(800);
+
+        Map<String, Integer> toolUsage = new HashMap<>();
+        toolUsage.put("web_search", 1);
+        usage.setTool_usage(toolUsage);
+
+        BigDecimal cost = CostCalculator.calculate("/v1/responses", priceInfoJson, usage);
+
+        assertNotNull("Cost should not be null", cost);
+
+        BigDecimal expectedTokenCost = new BigDecimal("2.0").add(new BigDecimal("2.4"));
+        BigDecimal expectedToolCost = new BigDecimal("0.5");
+        BigDecimal expectedTotalCost = expectedTokenCost.add(expectedToolCost);
+
+        System.out.println("Multiple Tool Calls Test - Expected: " + expectedTotalCost + ", Actual: " + cost);
+
+        assertEquals("Cost with multiple tool calls should be accurate",
+                expectedTotalCost.doubleValue(), cost.doubleValue(), 0.001);
+    }
+
+    /**
+     * 测试场景4：无工具调用时的计费
+     */
+    @Test
+    public void testCostWithoutToolUsage() {
+        ResponsesPriceInfo.RangePrice rangePrice = new ResponsesPriceInfo.RangePrice();
+        rangePrice.setMinToken(0);
+        rangePrice.setMaxToken(Integer.MAX_VALUE);
+        rangePrice.setInput(new BigDecimal("1.0"));
+        rangePrice.setOutput(new BigDecimal("3.0"));
+
+        ResponsesPriceInfo.Tier tier = new ResponsesPriceInfo.Tier();
+        tier.setInputRangePrice(rangePrice);
+
+        List<ResponsesPriceInfo.Tier> tiers = new ArrayList<>();
+        tiers.add(tier);
+
+        ResponsesPriceInfo priceInfo = new ResponsesPriceInfo();
+        priceInfo.setTiers(tiers);
+
+        String priceInfoJson = JacksonUtils.serialize(priceInfo);
+
+        ResponsesApiResponse.Usage usage = new ResponsesApiResponse.Usage();
+        usage.setInput_tokens(3000);
+        usage.setOutput_tokens(1000);
+
+        BigDecimal cost = CostCalculator.calculate("/v1/responses", priceInfoJson, usage);
+
+        assertNotNull("Cost should not be null", cost);
+
+        BigDecimal expectedCost = new BigDecimal("3.0").add(new BigDecimal("3.0"));
+
+        System.out.println("No Tool Test - Expected: " + expectedCost + ", Actual: " + cost);
+
+        assertEquals("Cost without tools should be accurate",
+                expectedCost.doubleValue(), cost.doubleValue(), 0.001);
+    }
+}

--- a/web/src/lib/types/openapi.ts
+++ b/web/src/lib/types/openapi.ts
@@ -143,6 +143,7 @@ export interface CompletionPriceInfo {
     unit: string;
     batchDiscount: number;
     tiers: Tier[];
+    toolPrices?: Record<string, number>;
 }
 
 export interface Tier {


### PR DESCRIPTION
支持直接指定Channel调用responses api；附带responses api的token/tool计费功能。已测计费正确/codex联调通过

Implement native OpenAI Responses API endpoint support with direct channel mode, allowing efficient handling of stateful conversations and tool-based pricing.

Backend changes:
- Add ResponsesController endpoint at /v1/responses and /v*/responses
- Implement ResponsesAdaptor and OpenAIResponsesAdaptor for protocol conversion
- Add ResponsesPriceInfo with tool-based pricing support (Map<toolName, price>)
- Extend CostCalculator with responses endpoint support for token and tool cost calculation
- Add ResponsesApiSseCallback for streaming event handling
- Support vendor-specific parameters via _extra_body with @JsonAnyGetter/@JsonAnySetter
- Add abandonFields to ResponsesApiProperty for parameter filtering
- Include ResponsesToolCostCalculationTest for tool pricing validation

Frontend changes:
- Add toolPrices field to CompletionPriceInfo TypeScript interface
- Extend CompletionPriceEditor with tool pricing configuration UI
- Support dynamic add/remove of tool price entries (e.g., web_search: 0.5)
- Fix decimal input handling for tool prices (step=0.01)

This enables direct integration with OpenAI Responses API for channels that support native protocol, with comprehensive cost calculation including per-tool-call pricing for advanced features like web search and code interpreter.

🤖 Generated with [Claude Code](https://claude.ai/code)