### PR TITLE
refactor: restructure exception hierarchy for better clarity

### DIFF
--- a/api/sdk/src/main/java/com/ke/bella/openapi/TypeSchema.java
+++ b/api/sdk/src/main/java/com/ke/bella/openapi/TypeSchema.java
@@ -1,6 +1,6 @@
 package com.ke.bella.openapi;
 
-import com.ke.bella.openapi.common.exception.ChannelException;
+import com.ke.bella.openapi.common.exception.BellaException;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
 
@@ -56,7 +56,7 @@ public class TypeSchema implements Serializable {
                     try {
                         return name.invoke(em).toString();
                     } catch (IllegalAccessException | InvocationTargetException e) {
-                        throw ChannelException.fromException(e);
+                        throw BellaException.fromException(e);
                     }
                 }).collect(Collectors.toList()));
             } else if(isPrimitiveOrWrapper(fieldType) || fieldType == String.class || fieldType == BigDecimal.class) {
@@ -87,7 +87,7 @@ public class TypeSchema implements Serializable {
             return schema;
         } catch (NoSuchMethodException e) {
             log.warn(e.getMessage(), e);
-            throw ChannelException.fromException(e);
+            throw BellaException.fromException(e);
         } catch (InstantiationException | IllegalAccessException e) {
             throw new RuntimeException(e);
         }

--- a/api/sdk/src/main/java/com/ke/bella/openapi/client/OpenapiClient.java
+++ b/api/sdk/src/main/java/com/ke/bella/openapi/client/OpenapiClient.java
@@ -14,7 +14,7 @@ import com.google.common.net.HttpHeaders;
 import com.ke.bella.openapi.BellaResponse;
 import com.ke.bella.openapi.EndpointProcessData;
 import com.ke.bella.openapi.apikey.ApikeyInfo;
-import com.ke.bella.openapi.common.exception.ChannelException;
+import com.ke.bella.openapi.common.exception.BellaException;
 import com.ke.bella.openapi.metadata.Model;
 import com.ke.bella.openapi.protocol.route.RouteRequest;
 import com.ke.bella.openapi.protocol.route.RouteResult;
@@ -56,7 +56,7 @@ public class OpenapiClient {
             }
             return apikeyInfo;
         } catch (ExecutionException e) {
-            throw ChannelException.fromException(e);
+            throw BellaException.fromException(e);
         }
     }
 
@@ -90,7 +90,7 @@ public class OpenapiClient {
         try {
             return modelCache.get(modelName, () -> requestModel(modelName));
         } catch (ExecutionException e) {
-            throw ChannelException.fromException(e);
+            throw BellaException.fromException(e);
         }
     }
 
@@ -123,7 +123,7 @@ public class OpenapiClient {
         BellaResponse<RouteResult> bellaResp = HttpUtils.httpRequest(request, new TypeReference<BellaResponse<RouteResult>>() {
         });
         if(bellaResp.getCode() != 200) {
-            throw ChannelException.fromResponse(bellaResp.getCode(), bellaResp.getMessage());
+            throw BellaException.fromResponse(bellaResp.getCode(), bellaResp.getMessage());
         }
         return bellaResp.getData();
     }
@@ -143,7 +143,7 @@ public class OpenapiClient {
         BellaResponse<Boolean> bellaResp = HttpUtils.httpRequest(request, new TypeReference<BellaResponse<Boolean>>() {
         });
         if(bellaResp.getCode() != 200) {
-            throw ChannelException.fromResponse(bellaResp.getCode(), bellaResp.getMessage());
+            throw BellaException.fromResponse(bellaResp.getCode(), bellaResp.getMessage());
         }
         return bellaResp.getData();
     }
@@ -161,7 +161,7 @@ public class OpenapiClient {
         BellaResponse<RouteResult> bellaResp = HttpUtils.httpRequest(request, new TypeReference<BellaResponse<RouteResult>>() {
         });
         if(bellaResp.getCode() != 200) {
-            throw ChannelException.fromResponse(bellaResp.getCode(), bellaResp.getMessage());
+            throw BellaException.fromResponse(bellaResp.getCode(), bellaResp.getMessage());
         }
         return bellaResp.getData();
     }
@@ -179,7 +179,7 @@ public class OpenapiClient {
                 new TypeReference<BellaResponse<Channel>>() {
                 });
         if(bellaResp.getCode() != 200) {
-            throw ChannelException.fromResponse(bellaResp.getCode(), bellaResp.getMessage());
+            throw BellaException.fromResponse(bellaResp.getCode(), bellaResp.getMessage());
         }
         return bellaResp.getData();
     }
@@ -199,7 +199,7 @@ public class OpenapiClient {
         BellaResponse<Boolean> bellaResp = HttpUtils.httpRequest(request, new TypeReference<BellaResponse<Boolean>>() {
         });
         if(bellaResp.getCode() != 200) {
-            throw ChannelException.fromResponse(bellaResp.getCode(), bellaResp.getMessage());
+            throw BellaException.fromResponse(bellaResp.getCode(), bellaResp.getMessage());
         }
         return bellaResp.getData();
     }

--- a/api/sdk/src/main/java/com/ke/bella/openapi/common/exception/BizParamCheckException.java
+++ b/api/sdk/src/main/java/com/ke/bella/openapi/common/exception/BizParamCheckException.java
@@ -7,7 +7,7 @@ import org.springframework.http.HttpStatus;
  *
  * @author chenhongliang001
  */
-public class BizParamCheckException extends ChannelException {
+public class BizParamCheckException extends BellaException {
 
     public BizParamCheckException(String message) {
         super(message);

--- a/api/sdk/src/main/java/com/ke/bella/openapi/common/exception/ResourceNotFoundException.java
+++ b/api/sdk/src/main/java/com/ke/bella/openapi/common/exception/ResourceNotFoundException.java
@@ -2,7 +2,7 @@ package com.ke.bella.openapi.common.exception;
 
 import org.springframework.http.HttpStatus;
 
-public class ResourceNotFoundException extends ChannelException {
+public class ResourceNotFoundException extends BellaException {
 
     public ResourceNotFoundException(String message) {
         super(message);

--- a/api/sdk/src/main/java/com/ke/bella/openapi/protocol/BellaStreamCallback.java
+++ b/api/sdk/src/main/java/com/ke/bella/openapi/protocol/BellaStreamCallback.java
@@ -3,7 +3,7 @@ package com.ke.bella.openapi.protocol;
 import java.io.IOException;
 import java.util.concurrent.CompletableFuture;
 
-import com.ke.bella.openapi.common.exception.ChannelException;
+import com.ke.bella.openapi.common.exception.BellaException;
 
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
@@ -32,7 +32,7 @@ public class BellaStreamCallback implements Callback {
     @Override
     public void onFailure(Call call, IOException e) {
         log.error("流式请求失败", e);
-        ChannelException exception = ChannelException.fromException(e);
+        BellaException exception = BellaException.fromException(e);
         if(!connectionInitFuture.isDone()) {
             connectionInitFuture.completeExceptionally(exception);
         } else {
@@ -45,7 +45,7 @@ public class BellaStreamCallback implements Callback {
         if(!response.isSuccessful()) {
             String errorMsg = "流式请求返回错误状态码: " + response.code() + ", message: " + response.message();
             log.error(errorMsg);
-            ChannelException exception = ChannelException.fromResponse(response.code(), response.message());
+            BellaException exception = new BellaException.ChannelException(response.code(), response.message());
             if(connectionInitFuture.isDone()) {
                 callback.finish(exception);
             } else {
@@ -77,7 +77,7 @@ public class BellaStreamCallback implements Callback {
             }
         } catch (IOException e) {
             log.error("读取流式数据失败", e);
-            ChannelException exception = ChannelException.fromException(e);
+            BellaException exception = BellaException.fromException(e);
             callback.finish(exception);
         } finally {
             if(body != null) {

--- a/api/sdk/src/main/java/com/ke/bella/openapi/protocol/Callbacks.java
+++ b/api/sdk/src/main/java/com/ke/bella/openapi/protocol/Callbacks.java
@@ -1,6 +1,6 @@
 package com.ke.bella.openapi.protocol;
 
-import com.ke.bella.openapi.common.exception.ChannelException;
+import com.ke.bella.openapi.common.exception.BellaException;
 import com.ke.bella.openapi.protocol.completion.StreamCompletionResponse;
 import com.ke.bella.openapi.utils.DateTimeUtils;
 import com.ke.bella.openapi.utils.JacksonUtils;
@@ -48,7 +48,7 @@ public interface Callbacks {
 
         void finish();
 
-        void finish(ChannelException exception);
+        void finish(BellaException exception);
 
         void send(Object data);
 
@@ -77,7 +77,7 @@ public interface Callbacks {
 
         void finish();
 
-        void finish(ChannelException exception);
+        void finish(BellaException exception);
     }
 
     interface WebSocketCallback extends StreamCallback {
@@ -124,7 +124,7 @@ public interface Callbacks {
                     msg = doCallback(msg);
                 }
             } catch (Exception e) {
-                finish(ChannelException.fromException(e));
+                finish(BellaException.fromException(e));
                 e.printStackTrace();
             } finally {
                 if(next != null) {
@@ -150,7 +150,7 @@ public interface Callbacks {
         }
 
         @Override
-        public void finish(ChannelException exception) {
+        public void finish(BellaException exception) {
             if(next != null) {
                 next.finish(exception);
             }
@@ -171,6 +171,6 @@ public interface Callbacks {
 
         void onComplete();
 
-        void onError(ChannelException exception);
+        void onError(BellaException exception);
     }
 }

--- a/api/sdk/src/main/java/com/ke/bella/openapi/protocol/completion/CompletionSseListener.java
+++ b/api/sdk/src/main/java/com/ke/bella/openapi/protocol/completion/CompletionSseListener.java
@@ -1,7 +1,7 @@
 package com.ke.bella.openapi.protocol.completion;
 
 import com.google.common.collect.ImmutableSet;
-import com.ke.bella.openapi.common.exception.ChannelException;
+import com.ke.bella.openapi.common.exception.BellaException;
 import com.ke.bella.openapi.protocol.BellaEventSourceListener;
 import com.ke.bella.openapi.protocol.Callbacks;
 import lombok.extern.slf4j.Slf4j;
@@ -49,15 +49,15 @@ public class CompletionSseListener extends BellaEventSourceListener {
 
     @Override
     public void onFailure(EventSource eventSource, Throwable t, Response response) {
-        ChannelException exception = null;
+        BellaException exception = null;
         try {
             if(t == null) {
                 exception = convertToException(response);
             } else {
-                exception = ChannelException.fromException(t);
+                exception = BellaException.fromException(t);
             }
         } catch (Exception e) {
-            exception = ChannelException.fromException(e);
+            exception = BellaException.fromException(e);
         } finally {
             if(connectionInitFuture.isDone()) {
                 callback.finish(exception);
@@ -67,20 +67,20 @@ public class CompletionSseListener extends BellaEventSourceListener {
         }
     }
 
-    public ChannelException convertToException(Response response) throws IOException {
+    public BellaException convertToException(Response response) throws IOException {
         String msg;
         try {
             msg = response.body().string();
             StreamCompletionResponse streamCompletionResponse = sseConverter.convert(null, null, msg);
             if(streamCompletionResponse != null && streamCompletionResponse.getError() != null) {
-                return new ChannelException.OpenAIException(response.code(), streamCompletionResponse.getError().getType(),
+                return new BellaException.ChannelException(response.code(), streamCompletionResponse.getError().getType(),
                         streamCompletionResponse.getError().getMessage(), streamCompletionResponse.getError());
             } else {
-                return new ChannelException.OpenAIException(response.code(), HttpStatus.valueOf(response.code()).getReasonPhrase(), msg);
+                return new BellaException.ChannelException(response.code(), HttpStatus.valueOf(response.code()).getReasonPhrase(), msg);
             }
         } catch (Exception e) {
             log.warn(e.getMessage(), e);
-            return ChannelException.fromResponse(response.code(), response.message());
+            return BellaException.fromResponse(response.code(), response.message());
         }
     }
 }

--- a/api/sdk/src/main/java/com/ke/bella/openapi/utils/HttpUtils.java
+++ b/api/sdk/src/main/java/com/ke/bella/openapi/utils/HttpUtils.java
@@ -15,7 +15,7 @@ import java.util.function.Function;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.ke.bella.openapi.BellaContext;
-import com.ke.bella.openapi.common.exception.ChannelException;
+import com.ke.bella.openapi.common.exception.BellaException;
 import com.ke.bella.openapi.protocol.BellaEventSourceListener;
 import com.ke.bella.openapi.protocol.BellaStreamCallback;
 import com.ke.bella.openapi.protocol.BellaWebSocketListener;
@@ -259,9 +259,9 @@ public class HttpUtils {
                 if(result == null) {
                     if(response.code() > 499 && response.code() < 600) {
                         String message = "供应商返回：code: " + response.code() + " message: " + response.message();
-                        throw ChannelException.fromResponse(503, message);
+                        throw new BellaException.ChannelException(503, message);
                     }
-                    throw ChannelException.fromResponse(response.code(), response.message());
+                    throw new BellaException.ChannelException(response.code(), response.message());
                 } else {
                     if(errorCallback != null) {
                         errorCallback.callback(result, response);
@@ -270,7 +270,7 @@ public class HttpUtils {
             }
             return result;
         } catch (IOException e) {
-            throw ChannelException.fromException(e);
+            throw BellaException.fromException(e);
         }
     }
 

--- a/api/server/src/main/java/com/ke/bella/openapi/endpoints/ChatController.java
+++ b/api/server/src/main/java/com/ke/bella/openapi/endpoints/ChatController.java
@@ -21,7 +21,7 @@ import com.ke.bella.openapi.EndpointContext;
 import com.ke.bella.openapi.EndpointProcessData;
 import com.ke.bella.openapi.annotations.EndpointAPI;
 import com.ke.bella.openapi.common.exception.BizParamCheckException;
-import com.ke.bella.openapi.common.exception.ChannelException;
+import com.ke.bella.openapi.common.exception.BellaException;
 import com.ke.bella.openapi.protocol.AdaptorManager;
 import com.ke.bella.openapi.protocol.ChannelRouter;
 import com.ke.bella.openapi.protocol.completion.CompletionAdaptor;
@@ -120,7 +120,7 @@ public class ChatController {
 
             // If we get here, all models failed
             if(lastException != null) {
-                throw ChannelException.fromException(lastException);
+                throw BellaException.fromException(lastException);
             } else {
                 throw new BizParamCheckException("所有指定的模型都无法处理请求");
             }

--- a/api/server/src/main/java/com/ke/bella/openapi/endpoints/VideoController.java
+++ b/api/server/src/main/java/com/ke/bella/openapi/endpoints/VideoController.java
@@ -25,7 +25,7 @@ import org.springframework.web.multipart.MultipartFile;
 import com.ke.bella.openapi.BellaContext;
 import com.ke.bella.openapi.EndpointContext;
 import com.ke.bella.openapi.annotations.EndpointAPI;
-import com.ke.bella.openapi.common.exception.ChannelException;
+import com.ke.bella.openapi.common.exception.BizParamCheckException;
 import com.ke.bella.openapi.common.exception.ResourceNotFoundException;
 import com.ke.bella.openapi.protocol.OpenapiListResponse;
 import com.ke.bella.openapi.protocol.video.VideoCreateRequest;
@@ -139,8 +139,7 @@ public class VideoController {
 
         List<ChannelDB> channels = channelService.listActives("model", model);
         if(CollectionUtils.isEmpty(channels)) {
-            throw new ChannelException.OpenAIException(503, "no_channel",
-                    "No channel available for model: " + model);
+            throw new BizParamCheckException("No channel available for model: " + model);
         }
 
         String spaceCode = EndpointContext.getApikey().getOwnerCode();

--- a/api/server/src/main/java/com/ke/bella/openapi/intercept/AuthorizationInterceptor.java
+++ b/api/server/src/main/java/com/ke/bella/openapi/intercept/AuthorizationInterceptor.java
@@ -14,7 +14,7 @@ import com.ke.bella.openapi.BellaContext;
 import com.ke.bella.openapi.EndpointContext;
 import com.ke.bella.openapi.Operator;
 import com.ke.bella.openapi.apikey.ApikeyInfo;
-import com.ke.bella.openapi.common.exception.ChannelException;
+import com.ke.bella.openapi.common.exception.BellaException;
 import com.ke.bella.openapi.service.ApikeyService;
 
 @Component
@@ -34,7 +34,7 @@ public class AuthorizationInterceptor extends com.ke.bella.openapi.server.interc
             String apikey = op.getManagerAk();
             ApikeyInfo apikeyInfo = apikeyService.verifyAuth(apikey);
             if(apikeyInfo == null) {
-                throw new ChannelException.AuthorizationException("apikey不存在");
+                throw new BellaException.AuthorizationException("apikey不存在");
             }
             op.getOptionalInfo().put("roles", apikeyInfo.getRolePath().getIncluded());
             op.getOptionalInfo().put("excludes", apikeyInfo.getRolePath().getExcluded());
@@ -52,7 +52,7 @@ public class AuthorizationInterceptor extends com.ke.bella.openapi.server.interc
                 }
                 // 备选 header 也为空，抛出异常
                 if (StringUtils.isEmpty(auth)) {
-                    throw new ChannelException.AuthorizationException("Authorization is empty");
+                    throw new BellaException.AuthorizationException("Authorization is empty");
                 }
             }
             ApikeyInfo apikeyInfo = apikeyService.verifyAuth(auth);
@@ -68,7 +68,7 @@ public class AuthorizationInterceptor extends com.ke.bella.openapi.server.interc
             EndpointContext.setApikey(apikeyInfo);
         }
         if(!hasPermission) {
-            throw new ChannelException.AuthorizationException("没有操作权限");
+            throw new BellaException.AuthorizationException("没有操作权限");
         }
         return true;
     }

--- a/api/server/src/main/java/com/ke/bella/openapi/intercept/BellaApiResponseAdvice.java
+++ b/api/server/src/main/java/com/ke/bella/openapi/intercept/BellaApiResponseAdvice.java
@@ -3,7 +3,7 @@ package com.ke.bella.openapi.intercept;
 import com.ke.bella.openapi.BellaResponse;
 import com.ke.bella.openapi.annotations.BellaAPI;
 import com.ke.bella.openapi.common.exception.BizParamCheckException;
-import com.ke.bella.openapi.common.exception.ChannelException;
+import com.ke.bella.openapi.common.exception.BellaException;
 import com.ke.bella.openapi.utils.JacksonUtils;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.MethodParameter;
@@ -69,8 +69,8 @@ public class BellaApiResponseAdvice implements ResponseBodyAdvice<Object> {
                 || e instanceof BizParamCheckException) {
             code = 400;
         }
-        if(e instanceof ChannelException) {
-            code = ((ChannelException) e).getHttpCode();
+        if(e instanceof BellaException) {
+            code = ((BellaException) e).getHttpCode();
         }
 
         if(code == 500) {

--- a/api/server/src/main/java/com/ke/bella/openapi/intercept/EndpointResponseAdvice.java
+++ b/api/server/src/main/java/com/ke/bella/openapi/intercept/EndpointResponseAdvice.java
@@ -14,7 +14,7 @@ import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
 
 import com.ke.bella.openapi.EndpointContext;
 import com.ke.bella.openapi.annotations.EndpointAPI;
-import com.ke.bella.openapi.common.exception.ChannelException;
+import com.ke.bella.openapi.common.exception.BellaException;
 import com.ke.bella.openapi.protocol.OpenapiResponse;
 import com.ke.bella.openapi.protocol.log.EndpointLogger;
 
@@ -56,12 +56,12 @@ public class EndpointResponseAdvice implements ResponseBodyAdvice<Object> {
     @ResponseBody
     public OpenapiResponse exceptionHandler(Exception exception) {
         String requestId = EndpointContext.getProcessData().getRequestId();
-        ChannelException e = ChannelException.fromException(exception);
+        BellaException e = BellaException.fromException(exception);
         logError(e.getHttpCode(), requestId, e.getMessage(), e);
         OpenapiResponse.OpenapiError error = e.convertToOpenapiError();
         OpenapiResponse openapiResponse = OpenapiResponse.errorResponse(error);
-        if(e instanceof ChannelException.SafetyCheckException) {
-            openapiResponse.setSensitives(((ChannelException.SafetyCheckException) e).getSensitive());
+        if(e instanceof BellaException.SafetyCheckException) {
+            openapiResponse.setSensitives(((BellaException.SafetyCheckException) e).getSensitive());
         }
         return openapiResponse;
     }

--- a/api/server/src/main/java/com/ke/bella/openapi/intercept/MonthQuotaInterceptor.java
+++ b/api/server/src/main/java/com/ke/bella/openapi/intercept/MonthQuotaInterceptor.java
@@ -2,7 +2,7 @@ package com.ke.bella.openapi.intercept;
 
 import com.ke.bella.openapi.EndpointContext;
 import com.ke.bella.openapi.apikey.ApikeyInfo;
-import com.ke.bella.openapi.common.exception.ChannelException;
+import com.ke.bella.openapi.common.exception.BellaException;
 import com.ke.bella.openapi.service.ApikeyService;
 import com.ke.bella.openapi.utils.DateTimeUtils;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -32,7 +32,7 @@ public class MonthQuotaInterceptor extends HandlerInterceptorAdapter {
             double costVal = cost.doubleValue() / 100.0;
             if(apikey.getMonthQuota().doubleValue() <= costVal) {
                 String msg = "已达每月额度上限, limit:" + apikey.getMonthQuota() + ", cost:" + costVal;
-                throw new ChannelException.RateLimitException(msg);
+                throw new BellaException.RateLimitException(msg);
             }
         }
         // 父ak的总额度不能超出
@@ -42,7 +42,7 @@ public class MonthQuotaInterceptor extends HandlerInterceptorAdapter {
             double costVal = cost.doubleValue() / 100.0;
             if(quota.doubleValue() <= costVal) {
                 String msg = "主ak的总额度已达上限, limit:" + quota + ", cost:" + costVal;
-                throw new ChannelException.RateLimitException(msg);
+                throw new BellaException.RateLimitException(msg);
             }
         }
         return true;

--- a/api/server/src/main/java/com/ke/bella/openapi/intercept/QpsRateLimitInterceptor.java
+++ b/api/server/src/main/java/com/ke/bella/openapi/intercept/QpsRateLimitInterceptor.java
@@ -2,7 +2,7 @@ package com.ke.bella.openapi.intercept;
 
 import com.ke.bella.openapi.EndpointContext;
 import com.ke.bella.openapi.apikey.ApikeyInfo;
-import com.ke.bella.openapi.common.exception.ChannelException;
+import com.ke.bella.openapi.common.exception.BellaException;
 import com.ke.bella.openapi.protocol.limiter.QpsCheckResult;
 import com.ke.bella.openapi.protocol.limiter.QpsLimiterManager;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -45,7 +45,7 @@ public class QpsRateLimitInterceptor extends HandlerInterceptorAdapter {
         if (!result.isAllowed()) {
             // 添加 Retry-After 响应头，建议客户端 1 秒后重试
             response.setHeader("Retry-After", "1");
-            throw new ChannelException.RateLimitException(
+            throw new BellaException.RateLimitException(
                     String.format("QPS 超过限制（当前: %d, 限制: %d），请 1 秒后重试",
                             result.getCurrentQps(), result.getLimit()));
         }

--- a/api/server/src/main/java/com/ke/bella/openapi/protocol/ChannelRouter.java
+++ b/api/server/src/main/java/com/ke/bella/openapi/protocol/ChannelRouter.java
@@ -4,7 +4,7 @@ import com.ke.bella.openapi.EndpointContext;
 import com.ke.bella.openapi.apikey.ApikeyInfo;
 import com.ke.bella.openapi.common.EntityConstants;
 import com.ke.bella.openapi.common.exception.BizParamCheckException;
-import com.ke.bella.openapi.common.exception.ChannelException;
+import com.ke.bella.openapi.common.exception.BellaException;
 import com.ke.bella.openapi.protocol.limiter.LimiterManager;
 import com.ke.bella.openapi.protocol.metrics.MetricsManager;
 import com.ke.bella.openapi.service.ChannelService;
@@ -124,10 +124,10 @@ public class ChannelRouter {
                         .collect(Collectors.toList());
             }
             if(CollectionUtils.isEmpty(filtered)) {
-                throw new ChannelException.AuthorizationException("未经安全合规审核，没有使用权限");
+                throw new BellaException.AuthorizationException("未经安全合规审核，没有使用权限");
             }
             if(freeAkOverload(EndpointContext.getProcessData().getAkCode(), entityCode)) {
-                throw new ChannelException.RateLimitException("当前使用试用额度,每分钟最多请求" + freeRpm + "次, 且并行请求数不能高于" + freeConcurrent);
+                throw new BellaException.RateLimitException("当前使用试用额度,每分钟最多请求" + freeRpm + "次, 且并行请求数不能高于" + freeConcurrent);
             }
         }
 
@@ -142,7 +142,7 @@ public class ChannelRouter {
                     .collect(Collectors.toList());
         }
         if(CollectionUtils.isEmpty(filtered)) {
-            throw new ChannelException.RateLimitException("渠道当前负载过高，请稍后重试");
+            throw new BellaException.RateLimitException("渠道当前负载过高，请稍后重试");
         }
         return filtered;
     }

--- a/api/server/src/main/java/com/ke/bella/openapi/protocol/asr/HuoshanStreamAsrCallback.java
+++ b/api/server/src/main/java/com/ke/bella/openapi/protocol/asr/HuoshanStreamAsrCallback.java
@@ -16,7 +16,7 @@ import java.util.zip.GZIPOutputStream;
 
 import com.ke.bella.openapi.EndpointProcessData;
 import com.ke.bella.openapi.TaskExecutor;
-import com.ke.bella.openapi.common.exception.ChannelException;
+import com.ke.bella.openapi.common.exception.BellaException;
 import com.ke.bella.openapi.protocol.Callbacks;
 import com.ke.bella.openapi.protocol.log.EndpointLogger;
 import com.ke.bella.openapi.utils.DateTimeUtils;
@@ -109,7 +109,7 @@ public class HuoshanStreamAsrCallback implements Callbacks.WebSocketCallback {
             sendFullClientRequest(webSocket);
         } catch (Exception e) {
             log.error("ASR onOpen error", e);
-            onError(ChannelException.fromException(e));
+            onError(BellaException.fromException(e));
         }
     }
 
@@ -123,7 +123,7 @@ public class HuoshanStreamAsrCallback implements Callbacks.WebSocketCallback {
         try {
             parseResponse(bytes.toByteArray(), webSocket);
         } catch (Exception e) {
-            onProcessError(ChannelException.fromException(e));
+            onProcessError(BellaException.fromException(e));
         }
     }
 
@@ -146,7 +146,7 @@ public class HuoshanStreamAsrCallback implements Callbacks.WebSocketCallback {
         int httpCode = response != null ? response.code() : 500;
         String message = t.getMessage();
 
-        onError(ChannelException.fromResponse(httpCode, message));
+        onError(new BellaException.ChannelException(httpCode, message));
     }
 
     @Override
@@ -156,9 +156,9 @@ public class HuoshanStreamAsrCallback implements Callbacks.WebSocketCallback {
             return true;
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-            throw ChannelException.fromException(e);
+            throw BellaException.fromException(e);
         } catch (ExecutionException | TimeoutException e) {
-            throw ChannelException.fromException(e);
+            throw BellaException.fromException(e);
         }
     }
 
@@ -179,13 +179,13 @@ public class HuoshanStreamAsrCallback implements Callbacks.WebSocketCallback {
     /**
      * 处理错误
      */
-    private void onError(ChannelException exception) {
+    private void onError(BellaException exception) {
         log.warn("ASR error: {}", exception.getMessage(), exception);
         sender.onError(exception);
         complete();
     }
 
-    private void onProcessError(ChannelException exception) {
+    private void  onProcessError(BellaException exception) {
         log.warn("ASR error: {}", exception.getMessage(), exception);
         sender.onError(exception);
         if(!request.isAsync()) {
@@ -202,7 +202,7 @@ public class HuoshanStreamAsrCallback implements Callbacks.WebSocketCallback {
             webSocket.send(ByteString.of(payload));
         } catch (Exception e) {
             log.warn("Error sending full client request", e);
-            onError(ChannelException.fromException(e));
+            onError(BellaException.fromException(e));
         }
     }
 
@@ -284,7 +284,7 @@ public class HuoshanStreamAsrCallback implements Callbacks.WebSocketCallback {
             byte[] payload = constructAudioPayload(audioData, isLast);
             webSocket.send(ByteString.of(payload));
         } catch (Exception e) {
-            onProcessError(ChannelException.fromException(e));
+            onProcessError(BellaException.fromException(e));
         }
     }
 
@@ -326,7 +326,7 @@ public class HuoshanStreamAsrCallback implements Callbacks.WebSocketCallback {
      */
     public void sendAudioDataInChunks(WebSocket webSocket, byte[] audioData, int chunkSize, int intervalMs) {
         if(audioData == null || audioData.length == 0) {
-            onProcessError(ChannelException.fromResponse(400, "No audio data to send"));
+            onProcessError(BellaException.fromResponse(400, "No audio data to send"));
             return;
         }
 
@@ -347,7 +347,7 @@ public class HuoshanStreamAsrCallback implements Callbacks.WebSocketCallback {
                     }
                 }
             } catch (Exception e) {
-                onProcessError(ChannelException.fromException(e));
+                onProcessError(BellaException.fromException(e));
             }
         });
     }
@@ -375,7 +375,7 @@ public class HuoshanStreamAsrCallback implements Callbacks.WebSocketCallback {
             payloadOffset += 4;
             payloadOffset += 4;
         } else {
-            onProcessError(ChannelException.fromResponse(400, "Unsupported message type"));
+            onProcessError(BellaException.fromResponse(400, "Unsupported message type"));
             return;
         }
 
@@ -453,7 +453,7 @@ public class HuoshanStreamAsrCallback implements Callbacks.WebSocketCallback {
     private void handleTranscriptionFailed(int code, String errorMsg) {
         log.error("Transcription failed: {}", errorMsg);
         isRunning = false;
-        sender.onError(ChannelException.fromResponse(getHttpCode(code), errorMsg));
+        sender.onError(new BellaException.ChannelException(getHttpCode(code), errorMsg));
         if(!request.isAsync()) {
             complete();
         }

--- a/api/server/src/main/java/com/ke/bella/openapi/protocol/asr/HuoshanStreamLMAsrCallback.java
+++ b/api/server/src/main/java/com/ke/bella/openapi/protocol/asr/HuoshanStreamLMAsrCallback.java
@@ -2,7 +2,7 @@ package com.ke.bella.openapi.protocol.asr;
 
 import com.ke.bella.openapi.EndpointProcessData;
 import com.ke.bella.openapi.TaskExecutor;
-import com.ke.bella.openapi.common.exception.ChannelException;
+import com.ke.bella.openapi.common.exception.BellaException;
 import com.ke.bella.openapi.protocol.Callbacks;
 import com.ke.bella.openapi.protocol.log.EndpointLogger;
 import com.ke.bella.openapi.utils.DateTimeUtils;
@@ -139,7 +139,7 @@ public class HuoshanStreamLMAsrCallback extends WebSocketListener implements Cal
             sendFullClientRequest(webSocket);
         } catch (Exception e) {
             log.error("WebSocket打开时出错", e);
-            onError(ChannelException.fromException(e));
+            onError(BellaException.fromException(e));
         }
     }
 
@@ -154,7 +154,7 @@ public class HuoshanStreamLMAsrCallback extends WebSocketListener implements Cal
             parseResponse(bytes.toByteArray(), webSocket);
         } catch (Exception e) {
             log.error("处理WebSocket消息时出错", e);
-            onError(ChannelException.fromException(e));
+            onError(BellaException.fromException(e));
         }
     }
 
@@ -173,7 +173,7 @@ public class HuoshanStreamLMAsrCallback extends WebSocketListener implements Cal
     @Override
     public void onFailure(WebSocket webSocket, Throwable t, Response response) {
         log.error("WebSocket连接失败", t);
-        onError(ChannelException.fromException(t));
+        onError(BellaException.fromException(t));
     }
 
     @Override
@@ -183,9 +183,9 @@ public class HuoshanStreamLMAsrCallback extends WebSocketListener implements Cal
             return true;
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-            throw ChannelException.fromException(e);
+            throw BellaException.fromException(e);
         } catch (ExecutionException | TimeoutException e) {
-            throw ChannelException.fromException(e);
+            throw BellaException.fromException(e);
         }
     }
 
@@ -206,7 +206,7 @@ public class HuoshanStreamLMAsrCallback extends WebSocketListener implements Cal
     /**
      * 处理错误
      */
-    private void onError(ChannelException exception) {
+    private void onError(BellaException exception) {
         if(!end) {
             end = true;
             sender.onError(exception);
@@ -216,7 +216,7 @@ public class HuoshanStreamLMAsrCallback extends WebSocketListener implements Cal
     /**
      * 处理处理过程中的错误
      */
-    private void onProcessError(ChannelException exception) {
+    private void onProcessError(BellaException exception) {
         if(!end) {
             sender.onError(exception);
         }
@@ -231,7 +231,7 @@ public class HuoshanStreamLMAsrCallback extends WebSocketListener implements Cal
             webSocket.send(ByteString.of(payload));
         } catch (Exception e) {
             log.warn("发送完整客户端请求时出错", e);
-            onError(ChannelException.fromException(e));
+            onError(BellaException.fromException(e));
         }
     }
 
@@ -357,7 +357,7 @@ public class HuoshanStreamLMAsrCallback extends WebSocketListener implements Cal
 
             webSocket.send(ByteString.of(audioOnlyRequest));
         } catch (Exception e) {
-            onProcessError(ChannelException.fromException(e));
+            onProcessError(BellaException.fromException(e));
         }
     }
 
@@ -385,7 +385,7 @@ public class HuoshanStreamLMAsrCallback extends WebSocketListener implements Cal
                 }
             } catch (Exception e) {
                 log.error("分块发送音频数据时出错", e);
-                onProcessError(ChannelException.fromException(e));
+                onProcessError(BellaException.fromException(e));
             }
         });
     }
@@ -567,7 +567,7 @@ public class HuoshanStreamLMAsrCallback extends WebSocketListener implements Cal
             complete();
         } catch (Exception e) {
             log.error("处理最终响应时出错", e);
-            onError(ChannelException.fromException(e));
+            onError(BellaException.fromException(e));
         }
     }
 
@@ -575,7 +575,7 @@ public class HuoshanStreamLMAsrCallback extends WebSocketListener implements Cal
      * 处理转录失败事件
      */
     private void handleTranscriptionFailed(int code, String errorMsg) {
-        onError(ChannelException.fromResponse(code, errorMsg));
+        onError(new BellaException.ChannelException(code, errorMsg));
     }
 
     /**

--- a/api/server/src/main/java/com/ke/bella/openapi/protocol/asr/TencentStreamAsrCallback.java
+++ b/api/server/src/main/java/com/ke/bella/openapi/protocol/asr/TencentStreamAsrCallback.java
@@ -1,8 +1,7 @@
 package com.ke.bella.openapi.protocol.asr;
 
 import com.ke.bella.openapi.EndpointProcessData;
-import com.ke.bella.openapi.TaskExecutor;
-import com.ke.bella.openapi.common.exception.ChannelException;
+import com.ke.bella.openapi.common.exception.BellaException;
 import com.ke.bella.openapi.protocol.Callbacks;
 import com.ke.bella.openapi.protocol.log.EndpointLogger;
 import com.ke.bella.openapi.utils.DateTimeUtils;
@@ -74,7 +73,7 @@ public class TencentStreamAsrCallback implements Callbacks.WebSocketCallback {
             isRunning = true;
         } catch (Exception e) {
             log.error("Tencent ASR onOpen error", e);
-            onError(ChannelException.fromException(e));
+            onError(BellaException.fromException(e));
         }
     }
 
@@ -86,7 +85,7 @@ public class TencentStreamAsrCallback implements Callbacks.WebSocketCallback {
             handleResponse(response, webSocket);
         } catch (Exception e) {
             log.error("Error parsing text message", e);
-            onProcessError(ChannelException.fromException(e));
+            onProcessError(BellaException.fromException(e));
         }
     }
 
@@ -116,7 +115,7 @@ public class TencentStreamAsrCallback implements Callbacks.WebSocketCallback {
         int httpCode = response != null ? response.code() : 500;
         String message = t.getMessage();
 
-        onError(ChannelException.fromResponse(httpCode, message));
+        onError(new BellaException.ChannelException(httpCode, message));
     }
 
     @Override
@@ -126,9 +125,9 @@ public class TencentStreamAsrCallback implements Callbacks.WebSocketCallback {
             return true;
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-            throw ChannelException.fromException(e);
+            throw BellaException.fromException(e);
         } catch (ExecutionException | TimeoutException e) {
-            throw ChannelException.fromException(e);
+            throw BellaException.fromException(e);
         }
     }
 
@@ -204,7 +203,7 @@ public class TencentStreamAsrCallback implements Callbacks.WebSocketCallback {
     private void handleTranscriptionFailed(int code, String errorMsg) {
         log.error("Transcription failed: code={}, message={}", code, errorMsg);
         isRunning = false;
-        sender.onError(ChannelException.fromResponse(getHttpCode(code), errorMsg));
+        sender.onError(new BellaException.ChannelException(getHttpCode(code), errorMsg));
 
         complete();
     }
@@ -250,7 +249,7 @@ public class TencentStreamAsrCallback implements Callbacks.WebSocketCallback {
     /**
      * 处理错误
      */
-    private void onError(ChannelException exception) {
+    private void onError(BellaException exception) {
         log.warn("Tencent ASR error: {}", exception.getMessage(), exception);
         sender.onError(exception);
         complete();
@@ -259,7 +258,7 @@ public class TencentStreamAsrCallback implements Callbacks.WebSocketCallback {
     /**
      * 处理处理过程中的错误
      */
-    private void onProcessError(ChannelException exception) {
+    private void onProcessError(BellaException exception) {
         log.warn("Tencent ASR process error: {}", exception.getMessage(), exception);
         sender.onError(exception);
         complete();

--- a/api/server/src/main/java/com/ke/bella/openapi/protocol/asr/flash/HuoshanAdaptor.java
+++ b/api/server/src/main/java/com/ke/bella/openapi/protocol/asr/flash/HuoshanAdaptor.java
@@ -5,15 +5,13 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
-import com.ke.bella.openapi.protocol.log.EndpointLogger;
-import com.ke.bella.openapi.protocol.realtime.RealTimeMessage;
 import okhttp3.WebSocket;
 import org.apache.commons.collections4.CollectionUtils;
 import org.springframework.stereotype.Component;
 
 import com.google.common.collect.Lists;
 import com.ke.bella.openapi.EndpointProcessData;
-import com.ke.bella.openapi.common.exception.ChannelException;
+import com.ke.bella.openapi.common.exception.BellaException;
 import com.ke.bella.openapi.protocol.BellaWebSocketListener;
 import com.ke.bella.openapi.protocol.Callbacks;
 import com.ke.bella.openapi.protocol.asr.AsrRequest;
@@ -140,7 +138,7 @@ public class HuoshanAdaptor implements FlashAsrAdaptor<HuoshanProperty> {
             }
             return response;
         } catch (Exception e) {
-            throw ChannelException.fromException(e);
+            throw BellaException.fromException(e);
         }
     }
 

--- a/api/server/src/main/java/com/ke/bella/openapi/protocol/asr/flash/QwenAdaptor.java
+++ b/api/server/src/main/java/com/ke/bella/openapi/protocol/asr/flash/QwenAdaptor.java
@@ -4,7 +4,7 @@ import com.ke.bella.openapi.EndpointProcessData;
 import com.ke.bella.openapi.server.OpenAiServiceFactory;
 import com.theokanning.openai.file.FileUrl;
 import com.theokanning.openai.service.OpenAiService;
-import com.ke.bella.openapi.common.exception.ChannelException;
+import com.ke.bella.openapi.common.exception.BellaException;
 import com.ke.bella.openapi.protocol.asr.QwenProperty;
 import com.ke.bella.openapi.protocol.asr.AsrRequest;
 import com.theokanning.openai.file.File;
@@ -46,7 +46,7 @@ public class QwenAdaptor implements FlashAsrAdaptor<QwenProperty> {
             return convertToFlashAsrResponse(aliResponse, processData);
 
         } catch (Exception e) {
-            throw ChannelException.fromException(e);
+            throw BellaException.fromException(e);
         }
     }
 

--- a/api/server/src/main/java/com/ke/bella/openapi/protocol/asr/realtime/TencentAdaptor.java
+++ b/api/server/src/main/java/com/ke/bella/openapi/protocol/asr/realtime/TencentAdaptor.java
@@ -1,6 +1,7 @@
 package com.ke.bella.openapi.protocol.asr.realtime;
 
 import com.ke.bella.openapi.EndpointProcessData;
+import com.ke.bella.openapi.common.exception.BizParamCheckException;
 import com.ke.bella.openapi.protocol.Callbacks;
 import com.ke.bella.openapi.protocol.asr.TencentProperty;
 import com.ke.bella.openapi.protocol.asr.TencentRealTimeAsrRequest;

--- a/api/server/src/main/java/com/ke/bella/openapi/protocol/completion/AwsAdaptor.java
+++ b/api/server/src/main/java/com/ke/bella/openapi/protocol/completion/AwsAdaptor.java
@@ -1,6 +1,6 @@
 package com.ke.bella.openapi.protocol.completion;
 
-import com.ke.bella.openapi.common.exception.ChannelException;
+import com.ke.bella.openapi.common.exception.BellaException;
 import com.ke.bella.openapi.protocol.Callbacks;
 import com.ke.bella.openapi.protocol.Callbacks.StreamCompletionCallback;
 import lombok.extern.slf4j.Slf4j;
@@ -45,7 +45,7 @@ public class AwsAdaptor implements CompletionAdaptor<AwsProperty> {
             ConverseResponse response = client.converse(awsRequest);
             return AwsCompletionConverter.convert2OpenAIResponse(response);
         } catch (BedrockRuntimeException bedrockException) {
-            throw ChannelException.fromResponse(bedrockException.statusCode(), bedrockException.getMessage());
+            throw new BellaException.ChannelException(bedrockException.statusCode(), bedrockException.getMessage());
         }
     }
 
@@ -120,10 +120,10 @@ public class AwsAdaptor implements CompletionAdaptor<AwsProperty> {
             log.warn(throwable.getMessage(), throwable);
             if(throwable instanceof BedrockRuntimeException) {
                 BedrockRuntimeException bedrockException = (BedrockRuntimeException) throwable;
-                callback.finish(ChannelException.fromResponse(bedrockException.statusCode(), bedrockException.getMessage()));
+                callback.finish(new BellaException.ChannelException(bedrockException.statusCode(), bedrockException.getMessage()));
                 return;
             }
-            callback.finish(ChannelException.fromException(throwable));
+            callback.finish(BellaException.fromException(throwable));
         }
     }
 }

--- a/api/server/src/main/java/com/ke/bella/openapi/protocol/completion/DirectPassthroughAdaptor.java
+++ b/api/server/src/main/java/com/ke/bella/openapi/protocol/completion/DirectPassthroughAdaptor.java
@@ -12,6 +12,7 @@ import com.ke.bella.openapi.EndpointContext;
 import com.ke.bella.openapi.EndpointProcessData;
 import com.ke.bella.openapi.TaskExecutor;
 import com.ke.bella.openapi.apikey.ApikeyInfo;
+import com.ke.bella.openapi.common.exception.BellaException;
 import com.ke.bella.openapi.protocol.AuthorizationProperty;
 import com.ke.bella.openapi.protocol.Callbacks;
 import com.ke.bella.openapi.protocol.completion.callback.StreamCompletionCallback;
@@ -142,7 +143,7 @@ public class DirectPassthroughAdaptor implements CompletionAdaptor<CompletionPro
 
         } catch (IOException e) {
             log.error("Direct passthrough error", e);
-            throw new RuntimeException(e);
+            throw new BellaException.ChannelException(502, "Direct passthrough error: " + e.getMessage());
         }
 
         return null;

--- a/api/server/src/main/java/com/ke/bella/openapi/protocol/completion/callback/ResponsesApiSseCallback.java
+++ b/api/server/src/main/java/com/ke/bella/openapi/protocol/completion/callback/ResponsesApiSseCallback.java
@@ -7,7 +7,7 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import com.ke.bella.openapi.EndpointProcessData;
 import com.ke.bella.openapi.apikey.ApikeyInfo;
-import com.ke.bella.openapi.common.exception.ChannelException;
+import com.ke.bella.openapi.common.exception.BellaException;
 import com.ke.bella.openapi.protocol.Callbacks;
 import com.ke.bella.openapi.protocol.completion.ResponsesApiResponse;
 import com.ke.bella.openapi.protocol.completion.ResponsesApiStreamEvent;
@@ -68,7 +68,7 @@ public class ResponsesApiSseCallback implements Callbacks.ResponsesApiSseCallbac
     }
 
     @Override
-    public void onError(ChannelException exception) {
+    public void onError(BellaException exception) {
         if(completed) {
             return;
         }

--- a/api/server/src/main/java/com/ke/bella/openapi/protocol/completion/callback/StreamCompletionCallback.java
+++ b/api/server/src/main/java/com/ke/bella/openapi/protocol/completion/callback/StreamCompletionCallback.java
@@ -11,7 +11,7 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 import com.google.common.collect.Lists;
 import com.ke.bella.openapi.EndpointProcessData;
 import com.ke.bella.openapi.apikey.ApikeyInfo;
-import com.ke.bella.openapi.common.exception.ChannelException;
+import com.ke.bella.openapi.common.exception.BellaException;
 import com.ke.bella.openapi.protocol.Callbacks;
 import com.ke.bella.openapi.protocol.OpenapiResponse;
 import com.ke.bella.openapi.protocol.completion.CompletionResponse;
@@ -122,7 +122,7 @@ public class StreamCompletionCallback implements Callbacks.StreamCompletionCallb
     }
 
     @Override
-    public void finish(ChannelException exception) {
+    public void finish(BellaException exception) {
         OpenapiResponse.OpenapiError openapiError = exception.convertToOpenapiError();
         StreamCompletionResponse response = StreamCompletionResponse.builder()
                 .created(DateTimeUtils.getCurrentSeconds())

--- a/api/server/src/main/java/com/ke/bella/openapi/protocol/completion/callback/ToolCallSimulatorCallback.java
+++ b/api/server/src/main/java/com/ke/bella/openapi/protocol/completion/callback/ToolCallSimulatorCallback.java
@@ -4,7 +4,7 @@ import org.apache.commons.lang3.StringUtils;
 
 import com.ke.bella.openapi.EndpointProcessData;
 import com.ke.bella.openapi.TaskExecutor;
-import com.ke.bella.openapi.common.exception.ChannelException;
+import com.ke.bella.openapi.common.exception.BellaException;
 import com.ke.bella.openapi.protocol.Callbacks;
 import com.ke.bella.openapi.protocol.completion.StreamCompletionResponse;
 import com.ke.bella.openapi.simulation.FunctionCallContentBuffer;
@@ -87,7 +87,7 @@ public class ToolCallSimulatorCallback extends Callbacks.StreamCompletionCallbac
     }
 
     @Override
-    public void finish(ChannelException exception) {
+    public void finish(BellaException exception) {
         if(isOpen) {
             buffer.finish();
         } else {

--- a/api/server/src/main/java/com/ke/bella/openapi/protocol/document/parse/DocParseAdaptor.java
+++ b/api/server/src/main/java/com/ke/bella/openapi/protocol/document/parse/DocParseAdaptor.java
@@ -1,7 +1,7 @@
 package com.ke.bella.openapi.protocol.document.parse;
 
 import com.ke.bella.openapi.TaskExecutor;
-import com.ke.bella.openapi.common.exception.ChannelException;
+import com.ke.bella.openapi.common.exception.BellaException;
 import com.ke.bella.openapi.protocol.IProtocolAdaptor;
 import com.ke.bella.openapi.utils.JacksonUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -66,7 +66,7 @@ public interface DocParseAdaptor<T extends DocParseProperty> extends IProtocolAd
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
                 log.error("Task waiting was interrupted - taskId: {}", taskId, e);
-                throw ChannelException.fromResponse(500, "Task waiting was interrupted for taskId: " + taskId);
+                throw BellaException.fromResponse(500, "Task waiting was interrupted for taskId: " + taskId);
             } catch (Exception e) {
                 log.warn("Error during task completion check - taskId: {}, error: {}", taskId, e.getMessage());
             }
@@ -75,7 +75,7 @@ public interface DocParseAdaptor<T extends DocParseProperty> extends IProtocolAd
         // 超时处理
         long elapsedTime = System.currentTimeMillis() - startTime;
         log.error("Task completion timeout in block mode - taskId: {}, elapsed time: {}ms", taskId, elapsedTime);
-        throw ChannelException.fromResponse(408, "Task completion timeout after " + maxTimeoutMillis + "ms for taskId: " + taskId);
+        throw BellaException.fromResponse(408, "Task completion timeout after " + maxTimeoutMillis + "ms for taskId: " + taskId);
     }
 
     default String endpoint() {

--- a/api/server/src/main/java/com/ke/bella/openapi/protocol/document/parse/LarkAdaptor.java
+++ b/api/server/src/main/java/com/ke/bella/openapi/protocol/document/parse/LarkAdaptor.java
@@ -1,8 +1,7 @@
 package com.ke.bella.openapi.protocol.document.parse;
 
-import com.ke.bella.openapi.TaskExecutor;
 import com.ke.bella.openapi.common.exception.BizParamCheckException;
-import com.ke.bella.openapi.common.exception.ChannelException;
+import com.ke.bella.openapi.common.exception.BellaException;
 import com.ke.bella.openapi.server.OpenAiServiceFactory;
 import com.lark.oapi.Client;
 import com.lark.oapi.service.docx.v1.model.Block;
@@ -62,7 +61,7 @@ public class LarkAdaptor implements DocParseAdaptor<LarkProperty> {
                     .taskId(TaskIdUtils.buildTaskId(channelCode, ticket))
                     .build();
         } catch (Exception e) {
-            throw ChannelException.fromException(e);
+            throw BellaException.fromException(e);
         }
     }
 
@@ -150,7 +149,7 @@ public class LarkAdaptor implements DocParseAdaptor<LarkProperty> {
         try {
             ListDocumentBlockResp resp = client.docx().v1().documentBlock().list(req);
             if(resp.getCode() != 0) {
-                throw ChannelException.fromResponse(502, resp.getMsg());
+                throw new BellaException.ChannelException(502, resp.getMsg());
             }
             ListDocumentBlockRespBody body = resp.getData();
             List<Block> blocks = new ArrayList<>(Arrays.asList(body.getItems()));
@@ -159,7 +158,7 @@ public class LarkAdaptor implements DocParseAdaptor<LarkProperty> {
             }
             return blocks;
         } catch (Exception e) {
-            throw ChannelException.fromException(e);
+            throw BellaException.fromException(e);
         }
     }
 

--- a/api/server/src/main/java/com/ke/bella/openapi/protocol/document/parse/LarkClientUtils.java
+++ b/api/server/src/main/java/com/ke/bella/openapi/protocol/document/parse/LarkClientUtils.java
@@ -1,6 +1,6 @@
 package com.ke.bella.openapi.protocol.document.parse;
 
-import com.ke.bella.openapi.common.exception.ChannelException;
+import com.ke.bella.openapi.common.exception.BellaException;
 import com.lark.oapi.Client;
 import com.lark.oapi.service.docx.v1.model.Image;
 import com.lark.oapi.service.drive.v1.model.CreateImportTaskReq;
@@ -40,11 +40,11 @@ public class LarkClientUtils {
                     .build();
             UploadAllFileResp resp = client.drive().v1().file().uploadAll(req);
             if(resp.getCode() != 0) {
-                throw ChannelException.fromResponse(502, resp.getMsg());
+                throw new BellaException.ChannelException(502, resp.getMsg());
             }
             return resp.getData().getFileToken();
         } catch (Exception e) {
-            throw ChannelException.fromException(e);
+            throw BellaException.fromException(e);
         }
     }
 
@@ -64,11 +64,11 @@ public class LarkClientUtils {
         try {
             CreateImportTaskResp resp = client.drive().v1().importTask().create(req);
             if(resp.getCode() != 0) {
-                throw ChannelException.fromResponse(502, resp.getMsg());
+                throw new BellaException.ChannelException(502, resp.getMsg());
             }
             return resp.getData().getTicket();
         } catch (Exception e) {
-            throw ChannelException.fromException(e);
+            throw BellaException.fromException(e);
         }
     }
 
@@ -79,7 +79,7 @@ public class LarkClientUtils {
         try {
             GetImportTaskResp resp = client.drive().v1().importTask().get(req);
             if(resp.getCode() != 0) {
-                throw ChannelException.fromResponse(502, resp.getMsg());
+                throw new BellaException.ChannelException(502, resp.getMsg());
             }
             DocParseResponse response = new DocParseResponse();
             switch (resp.getData().getResult().getJobStatus()) {
@@ -96,7 +96,7 @@ public class LarkClientUtils {
             }
             return response;
         } catch (Exception e) {
-            throw ChannelException.fromException(e);
+            throw BellaException.fromException(e);
         }
     }
 

--- a/api/server/src/main/java/com/ke/bella/openapi/protocol/gemini/VertexAdaptor.java
+++ b/api/server/src/main/java/com/ke/bella/openapi/protocol/gemini/VertexAdaptor.java
@@ -3,6 +3,7 @@ package com.ke.bella.openapi.protocol.gemini;
 import com.ke.bella.openapi.EndpointContext;
 import com.ke.bella.openapi.EndpointProcessData;
 import com.ke.bella.openapi.TaskExecutor;
+import com.ke.bella.openapi.common.exception.BellaException;
 import com.ke.bella.openapi.protocol.completion.CompletionResponse;
 import com.ke.bella.openapi.protocol.completion.VertexConverter;
 import com.ke.bella.openapi.protocol.completion.VertexProperty;
@@ -143,7 +144,7 @@ public class VertexAdaptor implements GeminiAdaptor<VertexProperty> {
 
         } catch (IOException e) {
             log.error("Gemini request failed", e);
-            throw new RuntimeException("Gemini request failed: " + e.getMessage(), e);
+            throw new BellaException.ChannelException(502, "Gemini request failed: " + e.getMessage());
         }
     }
 

--- a/api/server/src/main/java/com/ke/bella/openapi/protocol/images/variation/OpenAIVariationAdaptor.java
+++ b/api/server/src/main/java/com/ke/bella/openapi/protocol/images/variation/OpenAIVariationAdaptor.java
@@ -1,5 +1,6 @@
 package com.ke.bella.openapi.protocol.images.variation;
 
+import com.ke.bella.openapi.common.exception.BellaException;
 import com.ke.bella.openapi.protocol.images.ImagesVariationRequest;
 import com.ke.bella.openapi.protocol.images.ImagesProperty;
 import com.ke.bella.openapi.protocol.images.ImagesResponse;
@@ -80,7 +81,7 @@ public class OpenAIVariationAdaptor implements ImagesVariationAdaptor<ImagesProp
             return HttpUtils.httpRequest(httpRequest, ImagesResponse.class);
 
         } catch (IOException e) {
-            throw new RuntimeException("图片变化请求处理失败: " + e.getMessage(), e);
+            throw new BellaException.ChannelException(502, "图片变化请求处理失败: " + e.getMessage());
         }
     }
 }

--- a/api/server/src/main/java/com/ke/bella/openapi/protocol/message/AnthropicAdaptor.java
+++ b/api/server/src/main/java/com/ke/bella/openapi/protocol/message/AnthropicAdaptor.java
@@ -8,7 +8,7 @@ import org.springframework.stereotype.Component;
 
 import com.ke.bella.openapi.EndpointContext;
 import com.ke.bella.openapi.EndpointProcessData;
-import com.ke.bella.openapi.common.exception.ChannelException;
+import com.ke.bella.openapi.common.exception.BellaException;
 import com.ke.bella.openapi.protocol.BellaEventSourceListener;
 import com.ke.bella.openapi.protocol.Callbacks;
 import com.ke.bella.openapi.protocol.completion.AnthropicProperty;
@@ -29,9 +29,9 @@ public class AnthropicAdaptor implements MessageAdaptor<AnthropicProperty> {
 
     private final Callbacks.ChannelErrorCallback<MessageResponse> errorCallback = (errorResponse, res) -> {
         if(errorResponse != null && errorResponse.getError() != null) {
-            throw ChannelException.fromResponse(res.code(), errorResponse.getError().getMessage());
+            throw new BellaException.ChannelException(res.code(), errorResponse.getError().getMessage());
         }
-        throw ChannelException.fromResponse(res.code(), res.message());
+        throw new BellaException.ChannelException(res.code(), res.message());
     };
 
     @Override
@@ -183,15 +183,15 @@ public class AnthropicAdaptor implements MessageAdaptor<AnthropicProperty> {
 
         @Override
         public void onFailure(EventSource eventSource, Throwable t, Response response) {
-            ChannelException exception;
+            BellaException exception;
             try {
                 if(t == null) {
                     exception = convertToException(response);
                 } else {
-                    exception = ChannelException.fromException(t);
+                    exception = BellaException.fromException(t);
                 }
             } catch (Exception e) {
-                exception = ChannelException.fromException(e);
+                exception = BellaException.fromException(e);
             }
 
             if(connectionInitFuture.isDone()) {
@@ -201,13 +201,13 @@ public class AnthropicAdaptor implements MessageAdaptor<AnthropicProperty> {
             }
         }
 
-        private ChannelException convertToException(Response response) {
+        private BellaException convertToException(Response response) {
             try {
                 String msg = response.body().string();
-                return ChannelException.fromResponse(response.code(), msg);
+                return new BellaException.ChannelException(response.code(), msg);
             } catch (Exception e) {
                 log.warn(e.getMessage(), e);
-                return ChannelException.fromResponse(response.code(), response.message());
+                return new BellaException.ChannelException(response.code(), response.message());
             }
         }
     }

--- a/api/server/src/main/java/com/ke/bella/openapi/protocol/message/AwsMessageAdaptor.java
+++ b/api/server/src/main/java/com/ke/bella/openapi/protocol/message/AwsMessageAdaptor.java
@@ -2,7 +2,7 @@ package com.ke.bella.openapi.protocol.message;
 
 import com.ke.bella.openapi.EndpointContext;
 import com.ke.bella.openapi.EndpointProcessData;
-import com.ke.bella.openapi.common.exception.ChannelException;
+import com.ke.bella.openapi.common.exception.BellaException;
 import com.ke.bella.openapi.protocol.Callbacks;
 import com.ke.bella.openapi.protocol.completion.AwsClientManager;
 import com.ke.bella.openapi.protocol.completion.AwsMessageProperty;
@@ -65,7 +65,7 @@ public class AwsMessageAdaptor implements MessageAdaptor<AwsMessageProperty> {
             EndpointContext.getProcessData().setResponse(TransferToCompletionsUtils.convertResponse(messageResponse));
             return messageResponse;
         } catch (BedrockRuntimeException bedrockException) {
-            throw ChannelException.fromResponse(bedrockException.statusCode(), bedrockException.getMessage());
+            throw new BellaException.ChannelException(bedrockException.statusCode(), bedrockException.getMessage());
         }
     }
 
@@ -100,7 +100,7 @@ public class AwsMessageAdaptor implements MessageAdaptor<AwsMessageProperty> {
         try {
             client.invokeModelWithResponseStream(streamRequest, handler);
         } catch (BedrockRuntimeException bedrockException) {
-            throw ChannelException.fromResponse(bedrockException.statusCode(), bedrockException.getMessage());
+            throw new BellaException.ChannelException(bedrockException.statusCode(), bedrockException.getMessage());
         }
     }
 
@@ -172,10 +172,10 @@ public class AwsMessageAdaptor implements MessageAdaptor<AwsMessageProperty> {
             log.warn(throwable.getMessage(), throwable);
             if(throwable instanceof BedrockRuntimeException) {
                 BedrockRuntimeException bedrockException = (BedrockRuntimeException) throwable;
-                callback.finish(ChannelException.fromResponse(bedrockException.statusCode(), bedrockException.getMessage()));
+                callback.finish(new BellaException.ChannelException(bedrockException.statusCode(), bedrockException.getMessage()));
                 return;
             }
-            callback.finish(ChannelException.fromException(throwable));
+            callback.finish(BellaException.fromException(throwable));
         }
     }
 }

--- a/api/server/src/main/java/com/ke/bella/openapi/protocol/realtime/KeRealtimeCallback.java
+++ b/api/server/src/main/java/com/ke/bella/openapi/protocol/realtime/KeRealtimeCallback.java
@@ -1,7 +1,7 @@
 package com.ke.bella.openapi.protocol.realtime;
 
 import com.ke.bella.openapi.EndpointProcessData;
-import com.ke.bella.openapi.common.exception.ChannelException;
+import com.ke.bella.openapi.common.exception.BellaException;
 import com.ke.bella.openapi.protocol.Callbacks;
 import com.ke.bella.openapi.protocol.log.EndpointLogger;
 import com.ke.bella.openapi.utils.DateTimeUtils;
@@ -111,9 +111,9 @@ public class KeRealtimeCallback implements Callbacks.WebSocketCallback {
     @Override
     public void onFailure(WebSocket webSocket, Throwable t, Response response) {
         if(t != null) {
-            onError(ChannelException.fromException(t));
+            onError(BellaException.fromException(t));
         } else {
-            onError(ChannelException.fromResponse(response.code(), response.message()));
+            onError(new BellaException.ChannelException(response.code(), response.message()));
         }
     }
 
@@ -124,14 +124,14 @@ public class KeRealtimeCallback implements Callbacks.WebSocketCallback {
             return true;
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-            throw ChannelException.fromException(e);
+            throw BellaException.fromException(e);
         } catch (ExecutionException | TimeoutException e) {
             log.warn(e.getMessage(), e);
-            throw ChannelException.fromException(e);
+            throw BellaException.fromException(e);
         }
     }
 
-    private void onError(ChannelException exception) {
+    private void onError(BellaException exception) {
         log.warn("realtime error: {}", exception.getMessage(), exception);
         sender.onError(exception);
         complete();

--- a/api/server/src/main/java/com/ke/bella/openapi/protocol/realtime/RealTimeHandler.java
+++ b/api/server/src/main/java/com/ke/bella/openapi/protocol/realtime/RealTimeHandler.java
@@ -13,7 +13,7 @@ import org.springframework.web.socket.WebSocketSession;
 import org.springframework.web.socket.handler.TextWebSocketHandler;
 
 import com.ke.bella.openapi.EndpointProcessData;
-import com.ke.bella.openapi.common.exception.ChannelException;
+import com.ke.bella.openapi.common.exception.BellaException;
 import com.ke.bella.openapi.protocol.Callbacks;
 import com.ke.bella.openapi.protocol.Callbacks.WebSocketCallback;
 import com.ke.bella.openapi.protocol.asr.AsrProperty;
@@ -261,7 +261,7 @@ public class RealTimeHandler extends TextWebSocketHandler {
 
             @Override
             public void onError(Throwable e) {
-                ChannelException exception = ChannelException.fromException(e);
+                BellaException exception = BellaException.fromException(e);
                 RealTimeMessage res = sendErrorResponse(session, exception.getHttpCode() < 500 ? 40000000 : 50000000, exception.getMessage());
                 processData.setResponse(res);
             }

--- a/api/server/src/main/java/com/ke/bella/openapi/protocol/tts/HuoShanAdaptor.java
+++ b/api/server/src/main/java/com/ke/bella/openapi/protocol/tts/HuoShanAdaptor.java
@@ -3,13 +3,13 @@ package com.ke.bella.openapi.protocol.tts;
 import java.util.Base64;
 import java.util.UUID;
 
+import com.ke.bella.openapi.common.exception.BellaException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 
 import com.ke.bella.openapi.EndpointContext;
 import com.ke.bella.openapi.EndpointProcessData;
-import com.ke.bella.openapi.common.exception.ChannelException;
 import com.ke.bella.openapi.protocol.BellaWebSocketListener;
 import com.ke.bella.openapi.protocol.Callbacks;
 import com.ke.bella.openapi.protocol.log.EndpointLogger;
@@ -92,7 +92,7 @@ public class HuoShanAdaptor implements TtsAdaptor<HuoShanProperty> {
         if(huoshanResponse == null || huoshanResponse.getCode() != HuoShanResponseCodeEnum.OK.code || huoshanResponse.getData() == null) {
             HttpStatus status = getHttpStatus(HuoShanAdaptor.HuoShanResponseCodeEnum
                     .getByCode(huoshanResponse == null ? HuoShanResponseCodeEnum.OTHER_ERROR.code : huoshanResponse.getCode()));
-            throw new ChannelException.OpenAIException(status.value(), status.getReasonPhrase(),
+            throw new BellaException.ChannelException(status.value(), status.getReasonPhrase(),
                     huoshanResponse == null ? HuoShanResponseCodeEnum.OTHER_ERROR.message : huoshanResponse.getMessage());
         }
         return BASE64_DECODER.decode(huoshanResponse.getData());

--- a/api/server/src/main/java/com/ke/bella/openapi/protocol/tts/HuoshanStreamTtsCallback.java
+++ b/api/server/src/main/java/com/ke/bella/openapi/protocol/tts/HuoshanStreamTtsCallback.java
@@ -6,7 +6,7 @@ import java.util.UUID;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.ke.bella.openapi.EndpointProcessData;
-import com.ke.bella.openapi.common.exception.ChannelException;
+import com.ke.bella.openapi.common.exception.BellaException;
 import com.ke.bella.openapi.protocol.Callbacks;
 import com.ke.bella.openapi.protocol.OpenapiResponse;
 import com.ke.bella.openapi.protocol.log.EndpointLogger;
@@ -106,7 +106,7 @@ public class HuoshanStreamTtsCallback implements Callbacks.WebSocketCallback {
         case EVENT_SessionFailed: {
             String errorStr = response.optional.response_meta_json;
             Map<String, Object> map = JacksonUtils.toMap(errorStr);
-            ChannelException exception = ChannelException.fromResponse(convertCode((Integer) map.get("status_code")), (String) map.get("message"));
+            BellaException exception = new BellaException.ChannelException(convertCode((Integer) map.get("status_code")), (String) map.get("message"));
             onError(exception);
             break;
         }
@@ -154,13 +154,13 @@ public class HuoshanStreamTtsCallback implements Callbacks.WebSocketCallback {
 
     @Override
     public void onFailure(WebSocket webSocket, Throwable t, Response response) {
-        ChannelException exception;
+        BellaException exception;
         if(response != null) {
             int code = response.code();
             String msg = response.message();
-            exception = ChannelException.fromResponse(code, msg);
+            exception = new BellaException.ChannelException(code, msg);
         } else {
-            exception = ChannelException.fromException(t);
+            exception = BellaException.fromException(t);
         }
         onError(exception);
     }
@@ -184,7 +184,7 @@ public class HuoshanStreamTtsCallback implements Callbacks.WebSocketCallback {
         }
     }
 
-    void onError(ChannelException exception) {
+    void onError(BellaException exception) {
         complete();
         processData.setResponse(OpenapiResponse.errorResponse(exception.convertToOpenapiError()));
         log();

--- a/api/server/src/main/java/com/ke/bella/openapi/protocol/tts/OpenAIStreamTtsCallback.java
+++ b/api/server/src/main/java/com/ke/bella/openapi/protocol/tts/OpenAIStreamTtsCallback.java
@@ -2,10 +2,8 @@ package com.ke.bella.openapi.protocol.tts;
 
 import java.util.HashMap;
 
-import javax.servlet.AsyncContext;
-
 import com.ke.bella.openapi.EndpointProcessData;
-import com.ke.bella.openapi.common.exception.ChannelException;
+import com.ke.bella.openapi.common.exception.BellaException;
 import com.ke.bella.openapi.protocol.Callbacks;
 import com.ke.bella.openapi.protocol.OpenapiResponse;
 import com.ke.bella.openapi.protocol.log.EndpointLogger;
@@ -49,7 +47,7 @@ public class OpenAIStreamTtsCallback implements Callbacks.HttpStreamTtsCallback 
     }
 
     @Override
-    public void finish(ChannelException exception) {
+    public void finish(BellaException exception) {
         processData.setResponse(OpenapiResponse.errorResponse(exception.convertToOpenapiError()));
         finish();
     }

--- a/api/server/src/main/java/com/ke/bella/openapi/protocol/video/HuoshanAdaptor.java
+++ b/api/server/src/main/java/com/ke/bella/openapi/protocol/video/HuoshanAdaptor.java
@@ -2,6 +2,7 @@ package com.ke.bella.openapi.protocol.video;
 
 import org.springframework.stereotype.Component;
 
+import com.ke.bella.openapi.common.exception.BellaException;
 import com.ke.bella.openapi.utils.HttpUtils;
 import com.ke.bella.openapi.utils.JacksonUtils;
 
@@ -31,14 +32,14 @@ public class HuoshanAdaptor implements VideoAdaptor<HuoshanProperty> {
                 HuoshanVideoResponse.class);
 
         if(response.getCode() != null && response.getCode() != 0) {
-            throw new RuntimeException(
+            throw new BellaException.ChannelException(502,
                     "Huoshan API error: code=" + response.getCode() +
                             ", message=" + response.getMessage());
         }
 
         String channelVideoId = response.getId();
         if(channelVideoId == null) {
-            throw new RuntimeException("Huoshan API returned null id");
+            throw new BellaException.ChannelException(502, "Huoshan API returned null id");
         }
 
         return channelVideoId;
@@ -58,7 +59,7 @@ public class HuoshanAdaptor implements VideoAdaptor<HuoshanProperty> {
                 HuoshanVideoQueryResponse.class);
 
         if(response.getCode() != null && response.getCode() != 0) {
-            throw new RuntimeException(
+            throw new BellaException.ChannelException(502,
                     "Huoshan query API error: code=" + response.getCode() +
                             ", message=" + response.getMessage());
         }
@@ -80,13 +81,13 @@ public class HuoshanAdaptor implements VideoAdaptor<HuoshanProperty> {
                 HuoshanVideoQueryResponse.class);
 
         if(response.getCode() != null && response.getCode() != 0) {
-            throw new RuntimeException(
+            throw new BellaException.ChannelException(502,
                     "Huoshan query API error: code=" + response.getCode() +
                             ", message=" + response.getMessage());
         }
 
         if(response.getContent() == null || response.getContent().getVideo_url() == null) {
-            throw new RuntimeException("Video URL not found in Huoshan response");
+            throw new BellaException.ChannelException(502, "Video URL not found in Huoshan response");
         }
 
         String videoUrl = response.getContent().getVideo_url();
@@ -101,7 +102,7 @@ public class HuoshanAdaptor implements VideoAdaptor<HuoshanProperty> {
 
         } catch (java.io.IOException e) {
             log.error("[HuoshanAdaptor] Failed to transfer video: videoUrl={}", videoUrl, e);
-            throw new RuntimeException("Failed to transfer video: " + e.getMessage(), e);
+            throw new BellaException.ChannelException(502, "Failed to transfer video: " + e.getMessage());
         }
     }
 

--- a/api/server/src/main/java/com/ke/bella/openapi/safety/SafetyCheckDelegator.java
+++ b/api/server/src/main/java/com/ke/bella/openapi/safety/SafetyCheckDelegator.java
@@ -1,7 +1,7 @@
 package com.ke.bella.openapi.safety;
 
 import com.ke.bella.openapi.TaskExecutor;
-import com.ke.bella.openapi.common.exception.ChannelException;
+import com.ke.bella.openapi.common.exception.BellaException;
 
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -54,7 +54,7 @@ public class SafetyCheckDelegator<T extends SafetyCheckRequest> implements ISafe
                 addRiskData(result, request.isRequest());
             }
             return result;
-        } catch (ChannelException.SafetyCheckException e) {
+        } catch (BellaException.SafetyCheckException e) {
             log.warn("异步安全检测发现敏感数据: requestId={}, sensitiveData={}",
                     request.getRequestId(), e.getSensitive());
             if(e.getSensitive() != null) {

--- a/api/server/src/test/java/com/ke/bella/openapi/EndpointTest.java
+++ b/api/server/src/test/java/com/ke/bella/openapi/EndpointTest.java
@@ -33,7 +33,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StreamUtils;
 
 import com.google.common.collect.Lists;
-import com.ke.bella.openapi.common.exception.ChannelException;
+import com.ke.bella.openapi.common.exception.BellaException;
 import com.ke.bella.openapi.protocol.completion.CompletionResponse;
 import com.ke.bella.openapi.protocol.completion.Message;
 import com.ke.bella.openapi.protocol.completion.ResponseHelper;
@@ -172,7 +172,7 @@ public class EndpointTest {
                             }
                             responses.add(streamResponse);
                             if(streamResponse.getError() != null) {
-                                throw new ChannelException.OpenAIException(response.getStatus(), "", "", streamResponse.getError());
+                                throw new BellaException.ChannelException(response.getStatus(), "", "", streamResponse.getError());
                             }
                         }
                     }

--- a/api/spi/src/main/java/com/ke/bella/openapi/login/ClientLoginFilter.java
+++ b/api/spi/src/main/java/com/ke/bella/openapi/login/ClientLoginFilter.java
@@ -1,6 +1,6 @@
 package com.ke.bella.openapi.login;
 
-import com.ke.bella.openapi.common.exception.ChannelException;
+import com.ke.bella.openapi.common.exception.BellaException;
 
 import javax.servlet.Filter;
 import javax.servlet.FilterChain;
@@ -16,11 +16,11 @@ public class ClientLoginFilter implements Filter {
         HttpServletResponse httpResponse = (HttpServletResponse) response;
         try {
             filterChain.doFilter(request, response);
-        } catch (ChannelException.ClientNotLoginException clientNotLoginException) {
+        } catch (BellaException.ClientNotLoginException clientNotLoginException) {
             httpResponse.setStatus(401);
             httpResponse.setHeader(LoginFilter.REDIRECT_HEADER, clientNotLoginException.getRedirectUrl());
-        } catch (ChannelException channelException) {
-            httpResponse.sendError(channelException.getHttpCode(), channelException.getMessage());
+        } catch (BellaException bellaException) {
+            httpResponse.sendError(bellaException.getHttpCode(), bellaException.getMessage());
         } catch (Exception exception) {
             httpResponse.sendError(500, exception.getMessage());
         }

--- a/api/spi/src/main/java/com/ke/bella/openapi/login/session/HttpSessionManager.java
+++ b/api/spi/src/main/java/com/ke/bella/openapi/login/session/HttpSessionManager.java
@@ -3,7 +3,7 @@ package com.ke.bella.openapi.login.session;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.ke.bella.openapi.BellaResponse;
 import com.ke.bella.openapi.Operator;
-import com.ke.bella.openapi.common.exception.ChannelException;
+import com.ke.bella.openapi.common.exception.BellaException;
 import com.ke.bella.openapi.utils.HttpUtils;
 import com.ke.bella.openapi.utils.JacksonUtils;
 import okhttp3.Request;
@@ -65,9 +65,9 @@ public class HttpSessionManager implements SessionManager {
             if(response.code() != 200 && "true".equals(request.getHeader(CONSOLE_HEADER))) {
                 String redirectUrl = response.header(REDIRECT_HEADER);
                 if(response.code() == 401 && StringUtils.isNotEmpty(redirectUrl)) {
-                    throw new ChannelException.ClientNotLoginException(redirectUrl);
+                    throw new BellaException.ClientNotLoginException(redirectUrl);
                 }
-                throw ChannelException.fromResponse(response.code(), response.message());
+                throw BellaException.fromResponse(response.code(), response.message());
             }
             if(response.body() == null) {
                 return null;
@@ -76,7 +76,7 @@ public class HttpSessionManager implements SessionManager {
             }))
                     .orElse(new BellaResponse<>()).getData();
         } catch (IOException e) {
-            throw ChannelException.fromResponse(502, e.getMessage());
+            throw BellaException.fromResponse(502, e.getMessage());
         }
     }
 

--- a/api/spi/src/main/java/com/ke/bella/openapi/server/intercept/AuthorizationInterceptor.java
+++ b/api/spi/src/main/java/com/ke/bella/openapi/server/intercept/AuthorizationInterceptor.java
@@ -3,7 +3,7 @@ package com.ke.bella.openapi.server.intercept;
 import com.ke.bella.openapi.BellaContext;
 import com.ke.bella.openapi.Operator;
 import com.ke.bella.openapi.apikey.ApikeyInfo;
-import com.ke.bella.openapi.common.exception.ChannelException;
+import com.ke.bella.openapi.common.exception.BellaException;
 import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
 
 import javax.servlet.http.HttpServletRequest;
@@ -19,7 +19,7 @@ public class AuthorizationInterceptor extends HandlerInterceptorAdapter {
         }
         ApikeyInfo apikeyInfo = BellaContext.getApikeyIgnoreNull();
         if(apikeyInfo == null) {
-            throw new ChannelException.AuthorizationException("invalid Authorization header");
+            throw new BellaException.AuthorizationException("invalid Authorization header");
         }
 
         String user = request.getHeader("ucid");


### PR DESCRIPTION
问题：

供应商返回的错误使用了 fromResponse()
导致被错误标记为 "Internal Exception" 而非 "Channel Exception"
改动：

重命名基类 ChannelException -> BellaException
重命名 OpenAIException -> ChannelException（适用所有供应商）
所有协议适配器中的供应商错误统一使用 ChannelException