### PR TITLE
feat(tts): add text_type parameter support for speech API

### DIFF
--- a/api/sdk/src/main/java/com/ke/bella/openapi/protocol/tts/HuoShanRequest.java
+++ b/api/sdk/src/main/java/com/ke/bella/openapi/protocol/tts/HuoShanRequest.java
@@ -1,6 +1,9 @@
 package com.ke.bella.openapi.protocol.tts;
 
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.ke.bella.openapi.protocol.IMemoryClearable;
 import com.ke.bella.openapi.protocol.ITransfer;
@@ -9,10 +12,14 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.util.HashMap;
+import java.util.Map;
+
 @Data
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class HuoShanRequest implements IMemoryClearable, ITransfer {
     private App app;
     private User user;
@@ -42,18 +49,33 @@ public class HuoShanRequest implements IMemoryClearable, ITransfer {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public static class Audio {
         @JsonProperty("voice_type")
         private String voiceType = "BV001_streaming";
         private String encoding = "wav";
         @JsonProperty("speed_ratio")
         private Double speedRatio = 1.0;
+
+        @JsonIgnore
+        private Map<String, Object> additionalProperties = new HashMap<>();
+
+        @JsonAnyGetter
+        public Map<String, Object> getAdditionalProperties() {
+            return additionalProperties;
+        }
+
+        @JsonAnySetter
+        public void setAdditionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+        }
     }
 
     @Data
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public static class TextRequest {
         @JsonProperty("reqid")
         private String reqId;
@@ -61,6 +83,19 @@ public class HuoShanRequest implements IMemoryClearable, ITransfer {
         @JsonProperty("text_type")
         private String textType = "";
         private String operation = "query";
+
+        @JsonIgnore
+        private Map<String, Object> additionalProperties = new HashMap<>();
+
+        @JsonAnyGetter
+        public Map<String, Object> getAdditionalProperties() {
+            return additionalProperties;
+        }
+
+        @JsonAnySetter
+        public void setAdditionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+        }
     }
 
     // 内存清理相关字段和方法

--- a/api/sdk/src/main/java/com/ke/bella/openapi/protocol/tts/TtsRequest.java
+++ b/api/sdk/src/main/java/com/ke/bella/openapi/protocol/tts/TtsRequest.java
@@ -1,5 +1,7 @@
 package com.ke.bella.openapi.protocol.tts;
 
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -8,6 +10,7 @@ import com.ke.bella.openapi.protocol.UserRequest;
 import lombok.Data;
 
 import java.io.Serializable;
+import java.util.HashMap;
 import java.util.Map;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -25,6 +28,22 @@ public class TtsRequest implements UserRequest, Serializable, IMemoryClearable {
     boolean stream = true;
     Map<String, Object> speakers;
 
+    @JsonIgnore
+    private Map<String, Object> extra_body;
+
+    @JsonAnyGetter
+    public Map<String, Object> getExtraBodyFields() {
+        return extra_body != null && !extra_body.isEmpty() ? extra_body : null;
+    }
+
+    @JsonAnySetter
+    public void setExtraBodyField(String key, Object value) {
+        if(extra_body == null) {
+            extra_body = new HashMap<>();
+        }
+        extra_body.put(key, value);
+    }
+
     // 内存清理相关字段和方法
     @JsonIgnore
     private volatile boolean cleared = false;
@@ -34,6 +53,7 @@ public class TtsRequest implements UserRequest, Serializable, IMemoryClearable {
         if(!cleared) {
             // 清理最大的内存占用 - 输入文本可能很长
             this.input = null;
+            this.extra_body = null;
 
             // 标记为已清理
             this.cleared = true;

--- a/api/server/src/main/java/com/ke/bella/openapi/protocol/tts/HuoShanAdaptor.java
+++ b/api/server/src/main/java/com/ke/bella/openapi/protocol/tts/HuoShanAdaptor.java
@@ -1,6 +1,7 @@
 package com.ke.bella.openapi.protocol.tts;
 
 import java.util.Base64;
+import java.util.Map;
 import java.util.UUID;
 
 import com.ke.bella.openapi.common.exception.BellaException;
@@ -64,26 +65,65 @@ public class HuoShanAdaptor implements TtsAdaptor<HuoShanProperty> {
                 .build();
 
         HuoShanRequest.User user = HuoShanRequest.User.builder()
-                .uid("uid")
+                .uid(ttsRequest.getUser() != null ? ttsRequest.getUser() : "uid")
                 .build();
 
-        HuoShanRequest.Audio audio = HuoShanRequest.Audio.builder()
-                .voiceType(ttsRequest.getVoice() != null ? ttsRequest.getVoice() : "BV001_streaming")
-                .encoding(ttsRequest.getResponseFormat())
-                .speedRatio(ttsRequest.getSpeed() != null ? ttsRequest.getSpeed() : 1.0)
-                .build();
-
-        HuoShanRequest.TextRequest request = HuoShanRequest.TextRequest.builder()
-                .reqId(String.valueOf(UUID.randomUUID()))
-                .text(ttsRequest.getInput())
-                .operation("query")
-                .build();
+        HuoShanRequest.Audio audio = buildAudioFromRequest(ttsRequest);
+        HuoShanRequest.TextRequest request = buildTextRequestFromRequest(ttsRequest);
 
         return HuoShanRequest.builder()
                 .app(app)
                 .user(user)
                 .audio(audio)
                 .request(request)
+                .build();
+    }
+
+    private HuoShanRequest.Audio buildAudioFromRequest(TtsRequest ttsRequest) {
+        if (ttsRequest.getExtra_body() != null && ttsRequest.getExtra_body().containsKey("audio")) {
+            Object audioObj = ttsRequest.getExtra_body().get("audio");
+            if (audioObj instanceof Map) {
+                HuoShanRequest.Audio audio = JacksonUtils.convertValue((Map<String, Object>) audioObj, HuoShanRequest.Audio.class);
+                if (ttsRequest.getVoice() != null) {
+                    audio.setVoiceType(ttsRequest.getVoice());
+                }
+                if (ttsRequest.getResponseFormat() != null) {
+                    audio.setEncoding(ttsRequest.getResponseFormat());
+                }
+                if (ttsRequest.getSpeed() != null) {
+                    audio.setSpeedRatio(ttsRequest.getSpeed());
+                }
+                return audio;
+            }
+        }
+
+        return HuoShanRequest.Audio.builder()
+                .voiceType(ttsRequest.getVoice() != null ? ttsRequest.getVoice() : "BV001_streaming")
+                .encoding(ttsRequest.getResponseFormat() != null ? ttsRequest.getResponseFormat() : "wav")
+                .speedRatio(ttsRequest.getSpeed() != null ? ttsRequest.getSpeed() : 1.0)
+                .build();
+    }
+
+    private HuoShanRequest.TextRequest buildTextRequestFromRequest(TtsRequest ttsRequest) {
+        if (ttsRequest.getExtra_body() != null && ttsRequest.getExtra_body().containsKey("request")) {
+            Object requestObj = ttsRequest.getExtra_body().get("request");
+            if (requestObj instanceof Map) {
+                HuoShanRequest.TextRequest request = JacksonUtils.convertValue((Map<String, Object>) requestObj, HuoShanRequest.TextRequest.class);
+                if (ttsRequest.getInput() != null) {
+                    request.setText(ttsRequest.getInput());
+                }
+                if (request.getReqId() == null) {
+                    request.setReqId(String.valueOf(UUID.randomUUID()));
+                }
+                return request;
+            }
+        }
+
+        return HuoShanRequest.TextRequest.builder()
+                .reqId(String.valueOf(UUID.randomUUID()))
+                .text(ttsRequest.getInput())
+                .textType("")
+                .operation("query")
                 .build();
     }
 

--- a/api/server/src/main/java/com/ke/bella/openapi/protocol/tts/HuoshanStreamTtsCallback.java
+++ b/api/server/src/main/java/com/ke/bella/openapi/protocol/tts/HuoshanStreamTtsCallback.java
@@ -266,11 +266,11 @@ public class HuoshanStreamTtsCallback implements Callbacks.WebSocketCallback {
     @Data
     public static class AudioParams {
         @JsonProperty("speech_rate")
-        Double speechRete;
+        Double speechRate;
         String format;
 
         public AudioParams(TtsRequest request) {
-            this.speechRete = request.speed;
+            this.speechRate = request.speed;
             this.format = request.responseFormat;
         }
     }
@@ -279,17 +279,34 @@ public class HuoshanStreamTtsCallback implements Callbacks.WebSocketCallback {
     public static class ReqParams {
         String text;
         String speaker;
+        @JsonProperty("text_type")
+        String textType;
         @JsonProperty("audio_params")
         AudioParams audioParams;
 
         public ReqParams(TtsRequest request) {
+            this.audioParams = new AudioParams(request);
+
+            if (request.getExtra_body() != null && request.getExtra_body().containsKey("request")) {
+                Object requestObj = request.getExtra_body().get("request");
+                if (requestObj instanceof Map) {
+                    Map<String, Object> requestMap = (Map<String, Object>) requestObj;
+                    if (requestMap.containsKey("text_type")) {
+                        this.textType = String.valueOf(requestMap.get("text_type"));
+                    }
+                }
+            }
+
             this.text = request.input;
             if(request.voice == null) {
                 this.speaker = "zh_female_shuangkuaisisi_moon_bigtts";
             } else {
                 this.speaker = request.voice;
             }
-            this.audioParams = new AudioParams(request);
+
+            if (this.textType == null) {
+                this.textType = "";
+            }
         }
     }
 


### PR DESCRIPTION
Add text_type field to TTS request to support plain/ssml text formats. This feature is specifically designed for HuoShan TTS adapter.

Changes:
- Add text_type field to TtsRequest.java with @JsonProperty annotation
- Update HuoShanAdaptor to pass text_type in non-streaming mode
- Update HuoshanStreamTtsCallback to support text_type in streaming mode
- Default value is empty string to maintain backward compatibility