### PR TITLE
fix: prevent request field from being empty in endpoint logs

### DIFF
--- a/api/server/src/main/java/com/ke/bella/openapi/protocol/completion/AwsMessageAdaptor.java
+++ b/api/server/src/main/java/com/ke/bella/openapi/protocol/completion/AwsMessageAdaptor.java
@@ -28,7 +28,7 @@ public class AwsMessageAdaptor implements CompletionAdaptor<AwsMessageProperty> 
     @Override
     public CompletionResponse completion(CompletionRequest request, String url, AwsMessageProperty property) {
         MessageRequest messageRequest = TransferToCompletionsUtils.convertRequest(request);
-        request.clearLargeData();
+        clearLargeData(request);
         delegator.createMessages(messageRequest, url, property);
         return (CompletionResponse) EndpointContext.getProcessData().getResponse();
     }
@@ -36,7 +36,7 @@ public class AwsMessageAdaptor implements CompletionAdaptor<AwsMessageProperty> 
     @Override
     public void streamCompletion(CompletionRequest request, String url, AwsMessageProperty property, Callbacks.StreamCompletionCallback callback) {
         MessageRequest messageRequest = TransferToCompletionsUtils.convertRequest(request);
-        request.clearLargeData();
+        clearLargeData(request);
         delegator.streamMessages(messageRequest, url, property, callback);
     }
 }

--- a/api/server/src/main/java/com/ke/bella/openapi/protocol/message/AwsMessageAdaptor.java
+++ b/api/server/src/main/java/com/ke/bella/openapi/protocol/message/AwsMessageAdaptor.java
@@ -42,6 +42,7 @@ public class AwsMessageAdaptor implements MessageAdaptor<AwsMessageProperty> {
     @Override
     public MessageResponse createMessages(MessageRequest request, String url, AwsMessageProperty property) {
         String model = request.getModel();
+        Boolean stream = request.getStream();
         request.setModel(null);
         request.setStream(null);
         if(request.getMaxTokens() == null) {
@@ -51,6 +52,8 @@ public class AwsMessageAdaptor implements MessageAdaptor<AwsMessageProperty> {
 
         // 序列化请求并立即清理大型数据以释放内存
         byte[] requestBytes = JacksonUtils.toByte(request);
+        request.setModel(model);
+        request.setStream(stream);
         clearLargeData(request);
 
         BedrockRuntimeClient client = AwsClientManager.client(property.getRegion(), url, property.getAuth().getApiKey(),
@@ -72,6 +75,7 @@ public class AwsMessageAdaptor implements MessageAdaptor<AwsMessageProperty> {
     @Override
     public void streamMessages(MessageRequest request, String url, AwsMessageProperty property, Callbacks.StreamCompletionCallback callback) {
         String model = request.getModel();
+        Boolean stream = request.getStream();
         request.setModel(null);
         request.setStream(null);
         if(request.getMaxTokens() == null) {
@@ -82,7 +86,8 @@ public class AwsMessageAdaptor implements MessageAdaptor<AwsMessageProperty> {
         // 序列化请求并立即清理大型数据以释放内存
         byte[] requestBytes = JacksonUtils.toByte(request);
         clearLargeData(request);
-
+        request.setModel(model);
+        request.setStream(stream);
         BedrockRuntimeAsyncClient client = AwsClientManager.asyncClient(property.getRegion(), url, property.getAuth().getApiKey(),
                 property.getAuth().getSecret());
         InvokeModelWithResponseStreamRequest streamRequest = InvokeModelWithResponseStreamRequest.builder()

--- a/api/server/src/main/java/com/ke/bella/openapi/protocol/message/MessageDelegatorAdaptor.java
+++ b/api/server/src/main/java/com/ke/bella/openapi/protocol/message/MessageDelegatorAdaptor.java
@@ -51,7 +51,7 @@ public interface MessageDelegatorAdaptor<T extends CompletionProperty> extends M
         // 原有的委托逻辑
         CompletionAdaptor<T> delegator = decorateAdaptor(delegator(), property, EndpointContext.getProcessData());
         CompletionRequest completionRequest = TransferFromCompletionsUtils.convertRequest(request, isNativeSupport());
-        request.clearLargeData();
+        clearLargeData(request);
         CompletionResponse completionResponse = delegator.completion(completionRequest, url, property);
         EndpointContext.getProcessData().setResponse(completionResponse);
         return TransferFromCompletionsUtils.convertResponse(completionResponse, request.getModel());
@@ -74,7 +74,7 @@ public interface MessageDelegatorAdaptor<T extends CompletionProperty> extends M
         // 原有的委托逻辑
         CompletionAdaptor<T> delegator = decorateAdaptor(delegator(), property, EndpointContext.getProcessData());
         CompletionRequest completionRequest = TransferFromCompletionsUtils.convertRequest(request, isNativeSupport());
-        request.clearLargeData();
+        clearLargeData(request);
         delegator.streamCompletion(completionRequest, url, property, callback);
     }
 


### PR DESCRIPTION
https://github.com/LianjiaTech/bella-openapi/issues/535

1. Replace direct request.clearLargeData() calls with clearLargeData(request)
    in AwsMessageAdaptor and MessageDelegatorAdaptor to respect the large request
    threshold check in IProtocolAdaptor, avoiding unconditional clearing of messages/tools
2. Restore model and stream fields after serialization in AwsMessageAdaptor
    to prevent AWS-required null mutation from affecting logged request data
    