### PR TITLE
fix: prevent ThreadLocal pollution from async SSE error handling

### DIFF
--- a/api/server/src/main/java/com/ke/bella/openapi/intercept/EndpointResponseAdvice.java
+++ b/api/server/src/main/java/com/ke/bella/openapi/intercept/EndpointResponseAdvice.java
@@ -1,5 +1,7 @@
 package com.ke.bella.openapi.intercept;
 
+import static com.ke.bella.openapi.server.intercept.ConcurrentStartInterceptor.ASYNC_REQUEST_MARKER;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.MethodParameter;
 import org.springframework.http.HttpStatus;
@@ -7,6 +9,7 @@ import org.springframework.http.MediaType;
 import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.http.server.ServerHttpRequest;
 import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.http.server.ServletServerHttpRequest;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -36,15 +39,15 @@ public class EndpointResponseAdvice implements ResponseBodyAdvice<Object> {
     @Override
     public Object beforeBodyWrite(Object body, MethodParameter returnType, MediaType selectedContentType,
             Class<? extends HttpMessageConverter<?>> selectedConverterType, ServerHttpRequest request, ServerHttpResponse response) {
+        OpenapiResponse openapiResponse = body instanceof OpenapiResponse ? (OpenapiResponse) body : new OpenapiResponse();
+        applyErrorStatus(openapiResponse, response);
+        if(isAsyncRequest(request)) {
+            return body;
+        }
         if(EndpointContext.getProcessData().getResponse() == null) {
-            OpenapiResponse openapiResponse = body instanceof OpenapiResponse ? (OpenapiResponse) body : new OpenapiResponse();
             String requestId = EndpointContext.getProcessData().getRequestId();
-            if(openapiResponse.getError() == null) {
-                response.setStatusCode(HttpStatus.OK);
-            } else {
-                Integer httpCode = openapiResponse.getError().getHttpCode();
-                response.setStatusCode(httpCode == null ? HttpStatus.SERVICE_UNAVAILABLE : HttpStatus.valueOf(httpCode));
-                logError(httpCode, requestId, openapiResponse.getError().getMessage(), null);
+            if(openapiResponse.getError() != null) {
+                logError(openapiResponse.getError().getHttpCode(), requestId, openapiResponse.getError().getMessage(), null);
             }
             EndpointContext.getProcessData().setResponse(openapiResponse);
         }
@@ -64,6 +67,22 @@ public class EndpointResponseAdvice implements ResponseBodyAdvice<Object> {
             openapiResponse.setSensitives(((BellaException.SafetyCheckException) e).getSensitive());
         }
         return openapiResponse;
+    }
+
+    private void applyErrorStatus(OpenapiResponse openapiResponse, ServerHttpResponse response) {
+        if(openapiResponse.getError() == null) {
+            response.setStatusCode(HttpStatus.OK);
+        } else {
+            Integer httpCode = openapiResponse.getError().getHttpCode();
+            response.setStatusCode(httpCode == null ? HttpStatus.SERVICE_UNAVAILABLE : HttpStatus.valueOf(httpCode));
+        }
+    }
+
+    private boolean isAsyncRequest(ServerHttpRequest request) {
+        if(request instanceof ServletServerHttpRequest) {
+            return Boolean.TRUE.equals(((ServletServerHttpRequest) request).getServletRequest().getAttribute(ASYNC_REQUEST_MARKER));
+        }
+        return false;
     }
 
     private void logError(Integer httpCode, String requestId, String msg, Throwable e) {


### PR DESCRIPTION
When SSE completeWithError triggers Spring's exception handler on a different thread, EndpointResponseAdvice was mutating EndpointContext ThreadLocal and logging again. Use ASYNC_REQUEST_MARKER to detect async dispatch and skip EndpointContext writes and duplicate logging.

🤖 Generated with [Claude Code](https://claude.ai/code)