### PR TITLE
fix: unwrap CompletionException in AWS adaptor onError callbacks

### DIFF
--- a/api/server/src/main/java/com/ke/bella/openapi/protocol/completion/AwsAdaptor.java
+++ b/api/server/src/main/java/com/ke/bella/openapi/protocol/completion/AwsAdaptor.java
@@ -118,12 +118,14 @@ public class AwsAdaptor implements CompletionAdaptor<AwsProperty> {
         @Override
         public void accept(Throwable throwable) {
             log.warn(throwable.getMessage(), throwable);
-            if(throwable instanceof BedrockRuntimeException) {
-                BedrockRuntimeException bedrockException = (BedrockRuntimeException) throwable;
+            Throwable cause = throwable instanceof java.util.concurrent.CompletionException && throwable.getCause() != null
+                    ? throwable.getCause() : throwable;
+            if(cause instanceof BedrockRuntimeException) {
+                BedrockRuntimeException bedrockException = (BedrockRuntimeException) cause;
                 callback.finish(new BellaException.ChannelException(bedrockException.statusCode(), bedrockException.getMessage()));
                 return;
             }
-            callback.finish(BellaException.fromException(throwable));
+            callback.finish(BellaException.fromException(cause));
         }
     }
 }

--- a/api/server/src/main/java/com/ke/bella/openapi/protocol/message/AwsMessageAdaptor.java
+++ b/api/server/src/main/java/com/ke/bella/openapi/protocol/message/AwsMessageAdaptor.java
@@ -170,12 +170,14 @@ public class AwsMessageAdaptor implements MessageAdaptor<AwsMessageProperty> {
         @Override
         public void accept(Throwable throwable) {
             log.warn(throwable.getMessage(), throwable);
-            if(throwable instanceof BedrockRuntimeException) {
-                BedrockRuntimeException bedrockException = (BedrockRuntimeException) throwable;
+            Throwable cause = throwable instanceof java.util.concurrent.CompletionException && throwable.getCause() != null
+                    ? throwable.getCause() : throwable;
+            if(cause instanceof BedrockRuntimeException) {
+                BedrockRuntimeException bedrockException = (BedrockRuntimeException) cause;
                 callback.finish(new BellaException.ChannelException(bedrockException.statusCode(), bedrockException.getMessage()));
                 return;
             }
-            callback.finish(BellaException.fromException(throwable));
+            callback.finish(BellaException.fromException(cause));
         }
     }
 }


### PR DESCRIPTION
BedrockRuntimeAsyncClient returns CompletableFuture which wraps exceptions in CompletionException. The instanceof BedrockRuntimeException check was always false, causing errors to fall through to the generic handler and lose the HTTP status code from Bedrock.

🤖 Generated with [Claude Code](https://claude.ai/code)