### PR TITLE
fix: unwrap CompletionException to correctly propagate AWS error stat…

### DIFF
--- a/api/server/src/main/java/com/ke/bella/openapi/protocol/completion/AwsAdaptor.java
+++ b/api/server/src/main/java/com/ke/bella/openapi/protocol/completion/AwsAdaptor.java
@@ -16,6 +16,7 @@ import software.amazon.awssdk.services.bedrockruntime.model.ConverseStreamMetada
 import software.amazon.awssdk.services.bedrockruntime.model.ConverseStreamRequest;
 import software.amazon.awssdk.services.bedrockruntime.model.ConverseStreamResponseHandler;
 
+import java.util.concurrent.CompletionException;
 import java.util.function.Consumer;
 
 @Slf4j
@@ -118,12 +119,13 @@ public class AwsAdaptor implements CompletionAdaptor<AwsProperty> {
         @Override
         public void accept(Throwable throwable) {
             log.warn(throwable.getMessage(), throwable);
-            if(throwable instanceof BedrockRuntimeException) {
-                BedrockRuntimeException bedrockException = (BedrockRuntimeException) throwable;
+            Throwable cause = throwable instanceof CompletionException && throwable.getCause() != null ? throwable.getCause() : throwable;
+            if(cause instanceof BedrockRuntimeException) {
+                BedrockRuntimeException bedrockException = (BedrockRuntimeException) cause;
                 callback.finish(new BellaException.ChannelException(bedrockException.statusCode(), bedrockException.getMessage()));
                 return;
             }
-            callback.finish(BellaException.fromException(throwable));
+            callback.finish(BellaException.fromException(cause));
         }
     }
 }

--- a/api/server/src/main/java/com/ke/bella/openapi/protocol/message/AwsMessageAdaptor.java
+++ b/api/server/src/main/java/com/ke/bella/openapi/protocol/message/AwsMessageAdaptor.java
@@ -22,6 +22,7 @@ import software.amazon.awssdk.services.bedrockruntime.model.InvokeModelWithRespo
 import software.amazon.awssdk.services.bedrockruntime.model.PayloadPart;
 
 import java.util.UUID;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 
@@ -170,12 +171,13 @@ public class AwsMessageAdaptor implements MessageAdaptor<AwsMessageProperty> {
         @Override
         public void accept(Throwable throwable) {
             log.warn(throwable.getMessage(), throwable);
-            if(throwable instanceof BedrockRuntimeException) {
-                BedrockRuntimeException bedrockException = (BedrockRuntimeException) throwable;
+            Throwable cause = throwable instanceof CompletionException && throwable.getCause() != null ? throwable.getCause() : throwable;
+            if(cause instanceof BedrockRuntimeException) {
+                BedrockRuntimeException bedrockException = (BedrockRuntimeException) cause;
                 callback.finish(new BellaException.ChannelException(bedrockException.statusCode(), bedrockException.getMessage()));
                 return;
             }
-            callback.finish(BellaException.fromException(throwable));
+            callback.finish(BellaException.fromException(cause));
         }
     }
 }


### PR DESCRIPTION
AWS async SDK wraps BedrockRuntimeException inside CompletionException.                                                                                                        
Without unwrapping, the 400 ValidationException was not recognized as a                                                                                                        
BedrockRuntimeException, causing bella-openapi to return 500 instead of 400.  
<img width="1844" height="142" alt="image" src="https://github.com/user-attachments/assets/44c8f624-08c1-4ae1-8432-25c7951e5718" />
