### PR TITLE
refactor: extract AudioFileService to consolidate audio upload logic

### DIFF
--- a/api/server/src/main/java/com/ke/bella/openapi/endpoints/AudioController.java
+++ b/api/server/src/main/java/com/ke/bella/openapi/endpoints/AudioController.java
@@ -34,6 +34,7 @@ import com.ke.bella.openapi.protocol.speaker.SpeakerEmbeddingResponse;
 import com.ke.bella.openapi.protocol.tts.TtsAdaptor;
 import com.ke.bella.openapi.protocol.tts.TtsProperty;
 import com.ke.bella.openapi.protocol.tts.TtsRequest;
+import com.ke.bella.openapi.service.AudioFileService;
 import com.ke.bella.openapi.service.EndpointDataService;
 import com.ke.bella.openapi.tables.pojos.ChannelDB;
 import com.ke.bella.openapi.utils.JacksonUtils;
@@ -90,6 +91,8 @@ public class AudioController {
     private JobQueueProperties jobQueueProperties;
     @Autowired
     private EndpointDataService endpointDataService;
+    @Autowired
+    private AudioFileService audioFileService;
 
     /**
      * 实时语音识别WebSocket接口
@@ -212,6 +215,15 @@ public class AudioController {
         return TranscriptionsConverter.convertFlashAsrToOpenAI(flashResponse, request.getResponseFormat());
     }
 
+    @PostMapping(value = "/transcriptions/file/upload", consumes = "multipart/form-data")
+    public Map<String, String> uploadAudioFile(@RequestPart("file") MultipartFile file) throws IOException {
+        String filename = file.getOriginalFilename() != null ? file.getOriginalFilename() : "audio.wav";
+        String url = audioFileService.uploadAndGetUrl(file.getBytes(), filename);
+        Map<String, String> result = new HashMap<>();
+        result.put("url", url);
+        return result;
+    }
+
     @PostMapping("/transcriptions/file")
     public AudioTranscriptionResp transcribeAudio(@RequestBody AudioTranscriptionReq audioTranscriptionReq) {
         validateRequestParams(audioTranscriptionReq);
@@ -272,8 +284,8 @@ public class AudioController {
         if(audioTranscriptionReq.getModel() == null || audioTranscriptionReq.getModel().isEmpty()) {
             throw new IllegalArgumentException("Model is required");
         }
-        if(audioTranscriptionReq.getCallbackUrl() == null || audioTranscriptionReq.getCallbackUrl().isEmpty()) {
-            throw new IllegalArgumentException("Callback url is required");
+        if(audioTranscriptionReq.getCallbackUrl() == null) {
+            audioTranscriptionReq.setCallbackUrl("");
         }
         if(audioTranscriptionReq.getUrl() == null || audioTranscriptionReq.getUrl().isEmpty()) {
             throw new IllegalArgumentException("Url is required");

--- a/api/server/src/main/java/com/ke/bella/openapi/protocol/asr/flash/QwenAdaptor.java
+++ b/api/server/src/main/java/com/ke/bella/openapi/protocol/asr/flash/QwenAdaptor.java
@@ -1,13 +1,10 @@
 package com.ke.bella.openapi.protocol.asr.flash;
 
 import com.ke.bella.openapi.EndpointProcessData;
-import com.ke.bella.openapi.server.OpenAiServiceFactory;
-import com.theokanning.openai.file.FileUrl;
-import com.theokanning.openai.service.OpenAiService;
+import com.ke.bella.openapi.service.AudioFileService;
 import com.ke.bella.openapi.common.exception.BellaException;
 import com.ke.bella.openapi.protocol.asr.QwenProperty;
 import com.ke.bella.openapi.protocol.asr.AsrRequest;
-import com.theokanning.openai.file.File;
 import com.ke.bella.openapi.utils.HttpUtils;
 import com.ke.bella.openapi.utils.JacksonUtils;
 import okhttp3.MediaType;
@@ -21,13 +18,12 @@ import org.springframework.util.StringUtils;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.UUID;
 
 @Component("QwenFlashAsr")
 public class QwenAdaptor implements FlashAsrAdaptor<QwenProperty> {
 
     @Autowired
-    private OpenAiServiceFactory openAiServiceFactory;
+    private AudioFileService audioFileService;
 
     @Override
     public FlashAsrResponse asr(AsrRequest request, String url, QwenProperty property, EndpointProcessData processData) {
@@ -51,17 +47,8 @@ public class QwenAdaptor implements FlashAsrAdaptor<QwenProperty> {
     }
 
     private String uploadAudioAndGetUrl(AsrRequest request) {
-        OpenAiService openAiService = openAiServiceFactory.create();
-
-        // Upload file with proper filename based on format
-        String filename = UUID.randomUUID().toString() + "_audio." + (request.getFormat() != null ? request.getFormat() : "wav");
-
-        // Create file upload request
-        File openAiFile = openAiService.uploadFile("temp", request.getContent(), filename);
-
-        FileUrl fileUrlResponse = openAiService.retrieveFileUrl(openAiFile.getId());
-
-        return fileUrlResponse.getUrl();
+        String filename = "audio." + (request.getFormat() != null ? request.getFormat() : "wav");
+        return audioFileService.uploadAndGetUrl(request.getContent(), filename);
     }
 
     private QwenFlashAsrRequest buildAliRequest(AsrRequest request, String audioUrl, QwenProperty property) {

--- a/api/server/src/main/java/com/ke/bella/openapi/service/AudioFileService.java
+++ b/api/server/src/main/java/com/ke/bella/openapi/service/AudioFileService.java
@@ -1,0 +1,22 @@
+package com.ke.bella.openapi.service;
+
+import com.ke.bella.openapi.server.OpenAiServiceFactory;
+import com.theokanning.openai.file.File;
+import com.theokanning.openai.service.OpenAiService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+@Service
+public class AudioFileService {
+    @Autowired
+    private OpenAiServiceFactory openAiServiceFactory;
+
+    public String uploadAndGetUrl(byte[] content, String filename) {
+        String uniqueName = UUID.randomUUID() + "_" + filename;
+        OpenAiService service = openAiServiceFactory.create();
+        File file = service.uploadFile("temp", content, uniqueName);
+        return service.retrieveFileUrl(file.getId()).getUrl();
+    }
+}


### PR DESCRIPTION
## Summary
- 新建 `AudioFileService`，将 `AudioController` 和 `QwenAdaptor` 中重复的"上传文件 → 获取URL"逻辑提取为共享服务
- 新增 `/v1/audio/transcriptions/file/upload` 接口用于音频文件上传
- `callbackUrl` 为 null 时自动填充空字符串，不再抛出异常

🤖 Generated with [Claude Code](https://claude.com/claude-code)