### PR TITLE
fix: callbackUrl 为空时自动填充，不再抛异常

### DIFF
--- a/api/server/src/main/java/com/ke/bella/openapi/endpoints/AudioController.java
+++ b/api/server/src/main/java/com/ke/bella/openapi/endpoints/AudioController.java
@@ -272,8 +272,8 @@ public class AudioController {
         if(audioTranscriptionReq.getModel() == null || audioTranscriptionReq.getModel().isEmpty()) {
             throw new IllegalArgumentException("Model is required");
         }
-        if(audioTranscriptionReq.getCallbackUrl() == null || audioTranscriptionReq.getCallbackUrl().isEmpty()) {
-            throw new IllegalArgumentException("Callback url is required");
+        if(audioTranscriptionReq.getCallbackUrl() == null) {
+            audioTranscriptionReq.setCallbackUrl("");
         }
         if(audioTranscriptionReq.getUrl() == null || audioTranscriptionReq.getUrl().isEmpty()) {
             throw new IllegalArgumentException("Url is required");


### PR DESCRIPTION
## Summary
- callbackUrl 为 null 时自动填充空字符串，不再抛出 IllegalArgumentException

## Test plan
- [ ] 调用 `/v1/audio/transcriptions/file` 接口时不传 callbackUrl，验证不再报错
- [ ] 传入 callbackUrl 时功能正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)