### PR TITLE
feat(realtime): add event_level field to Payload

### DIFF
--- a/api/sdk/src/main/java/com/ke/bella/openapi/protocol/realtime/RealTimeMessage.java
+++ b/api/sdk/src/main/java/com/ke/bella/openapi/protocol/realtime/RealTimeMessage.java
@@ -283,6 +283,13 @@ public class RealTimeMessage extends OpenapiResponse {
          */
         @JsonProperty("hot_words_table_id")
         private String hotWordsTableId;
+
+        /**
+         * 事件级别
+         * 控制返回的事件级别，event_level >= 2 时返回 VAD 事件
+         */
+        @JsonProperty("event_level")
+        private Integer eventLevel;
     }
 
     /**


### PR DESCRIPTION
## Summary

- 在 `RealTimeMessage.Payload` 中添加 `event_level` 字段，使网关能够透传客户端传递的事件级别到后端服务
- 当 `event_level >= 2` 时，后端服务会返回 VAD 事件（`VOICE_QUIET`、`VOICE_SPEAKING` 等）
- 仅添加字段声明，网关 JSON → POJO → JSON 透传链路自动生效，无需改动 Handler 或 Adaptor

🤖 Generated with [Claude Code](https://claude.com/claude-code)