### PR TITLE
feat: add HuoShanV3 HTTP Chunked TTS adapter

### DIFF
--- a/api/sdk/src/main/java/com/ke/bella/openapi/protocol/tts/HuoShanV3Property.java
+++ b/api/sdk/src/main/java/com/ke/bella/openapi/protocol/tts/HuoShanV3Property.java
@@ -1,0 +1,12 @@
+package com.ke.bella.openapi.protocol.tts;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@EqualsAndHashCode(callSuper = true)
+@Data
+public class HuoShanV3Property extends TtsProperty {
+    String appId;
+    String accessKey;
+    String resourceId;
+}

--- a/api/sdk/src/main/java/com/ke/bella/openapi/protocol/tts/HuoShanV3Request.java
+++ b/api/sdk/src/main/java/com/ke/bella/openapi/protocol/tts/HuoShanV3Request.java
@@ -1,0 +1,152 @@
+package com.ke.bella.openapi.protocol.tts;
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.ke.bella.openapi.protocol.IMemoryClearable;
+import com.ke.bella.openapi.protocol.ITransfer;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class HuoShanV3Request implements IMemoryClearable, ITransfer {
+    private User user;
+    @JsonProperty("req_params")
+    private ReqParams reqParams;
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class User {
+        private String uid;
+    }
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class ReqParams {
+        private String text;
+        private String speaker;
+        @JsonProperty("audio_params")
+        private AudioParams audioParams;
+
+        @JsonIgnore
+        private Map<String, Object> additionalProperties = new HashMap<>();
+
+        @JsonAnyGetter
+        public Map<String, Object> getAdditionalProperties() {
+            return additionalProperties;
+        }
+
+        @JsonAnySetter
+        public void setAdditionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+        }
+    }
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class AudioParams {
+        private String format;
+        @JsonProperty("sample_rate")
+        private Integer sampleRate;
+        @JsonProperty("speech_rate")
+        private Integer speechRate;
+
+        @JsonIgnore
+        private Map<String, Object> additionalProperties = new HashMap<>();
+
+        @JsonAnyGetter
+        public Map<String, Object> getAdditionalProperties() {
+            return additionalProperties;
+        }
+
+        @JsonAnySetter
+        public void setAdditionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+        }
+    }
+
+    public static HuoShanV3Request from(TtsRequest ttsRequest, HuoShanV3Property property) {
+        User user = User.builder()
+                .uid(ttsRequest.getUser() != null ? ttsRequest.getUser() : "")
+                .build();
+
+        AudioParams audioParams = AudioParams.builder()
+                .format(ttsRequest.getResponseFormat() != null ? ttsRequest.getResponseFormat()
+                        : (property.getDefaultContentType() != null ? property.getDefaultContentType() : "mp3"))
+                .sampleRate(ttsRequest.getSampleRate() != null ? ttsRequest.getSampleRate()
+                        : (property.getDefaultSampleRate() != null ? property.getDefaultSampleRate() : 24000))
+                .build();
+
+        // Support extra_body["audio_params"] pass-through
+        if (ttsRequest.getExtra_body() != null && ttsRequest.getExtra_body().containsKey("audio_params")) {
+            Object audioObj = ttsRequest.getExtra_body().get("audio_params");
+            if (audioObj instanceof Map) {
+                @SuppressWarnings("unchecked")
+                Map<String, Object> audioMap = (Map<String, Object>) audioObj;
+                for (Map.Entry<String, Object> entry : audioMap.entrySet()) {
+                    audioParams.setAdditionalProperty(entry.getKey(), entry.getValue());
+                }
+            }
+        }
+
+        ReqParams reqParams = ReqParams.builder()
+                .text(ttsRequest.getInput())
+                .speaker(ttsRequest.getVoice() != null ? ttsRequest.getVoice() : property.getDefaultVoice())
+                .audioParams(audioParams)
+                .build();
+
+        // Support extra_body["req_params"] pass-through
+        if (ttsRequest.getExtra_body() != null && ttsRequest.getExtra_body().containsKey("req_params")) {
+            Object reqObj = ttsRequest.getExtra_body().get("req_params");
+            if (reqObj instanceof Map) {
+                @SuppressWarnings("unchecked")
+                Map<String, Object> reqMap = (Map<String, Object>) reqObj;
+                for (Map.Entry<String, Object> entry : reqMap.entrySet()) {
+                    reqParams.setAdditionalProperty(entry.getKey(), entry.getValue());
+                }
+            }
+        }
+
+        return HuoShanV3Request.builder()
+                .user(user)
+                .reqParams(reqParams)
+                .build();
+    }
+
+    @JsonIgnore
+    private volatile boolean cleared = false;
+
+    @Override
+    public void clearLargeData() {
+        if (!cleared) {
+            if (this.reqParams != null) {
+                this.reqParams.text = null;
+            }
+            this.cleared = true;
+        }
+    }
+
+    @Override
+    public boolean isCleared() {
+        return cleared;
+    }
+}

--- a/api/sdk/src/main/java/com/ke/bella/openapi/protocol/tts/HuoShanV3Response.java
+++ b/api/sdk/src/main/java/com/ke/bella/openapi/protocol/tts/HuoShanV3Response.java
@@ -1,0 +1,32 @@
+package com.ke.bella.openapi.protocol.tts;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class HuoShanV3Response implements Serializable {
+    private int code;
+    private String message;
+    private String data;
+    private Object sentence;
+    private Object usage;
+
+    public static final int CODE_OK = 0;
+    public static final int CODE_SESSION_FINISH = 20000000;
+    public static final int CODE_TEXT_LIMIT = 40402003;
+    public static final int CODE_PERMISSION = 45000000;
+    public static final int CODE_SERVER_ERROR = 55000000;
+
+    public boolean isSuccess() {
+        return code == CODE_OK || code == CODE_SESSION_FINISH;
+    }
+}

--- a/api/server/src/main/java/com/ke/bella/openapi/protocol/tts/HuoShanV3Adaptor.java
+++ b/api/server/src/main/java/com/ke/bella/openapi/protocol/tts/HuoShanV3Adaptor.java
@@ -1,0 +1,158 @@
+package com.ke.bella.openapi.protocol.tts;
+
+import java.io.ByteArrayOutputStream;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import com.ke.bella.openapi.common.exception.BellaException;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+
+import com.ke.bella.openapi.EndpointProcessData;
+import com.ke.bella.openapi.protocol.BellaStreamCallback;
+import com.ke.bella.openapi.protocol.Callbacks;
+import com.ke.bella.openapi.protocol.log.EndpointLogger;
+import com.ke.bella.openapi.utils.HttpUtils;
+import com.ke.bella.openapi.utils.JacksonUtils;
+
+import lombok.extern.slf4j.Slf4j;
+import okhttp3.MediaType;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+
+/**
+ * 火山引擎 V3 HTTP Chunked TTS 适配器。
+ * 响应格式为每行一个 JSON，通过 BellaStreamCallback 流式读取并解析。
+ */
+@Slf4j
+@Component("HuoShanV3Tts")
+public class HuoShanV3Adaptor implements TtsAdaptor<HuoShanV3Property> {
+
+    @Override
+    public byte[] tts(TtsRequest request, String url, HuoShanV3Property property) {
+        HuoShanV3Request v3Request = HuoShanV3Request.from(request, property);
+        Request httpRequest = buildHttpRequest(url, v3Request, property);
+        clearLargeData(request, v3Request);
+        AudioCollector collector = new AudioCollector();
+        HttpUtils.streamRequest(httpRequest, new BellaStreamCallback(collector.getDelegate()));
+        return collector.getAudioBytes();
+    }
+
+    @Override
+    public void streamTts(TtsRequest request, String url, HuoShanV3Property property, Callbacks.StreamCallback callback) {
+        HuoShanV3Request v3Request = HuoShanV3Request.from(request, property);
+        Request httpRequest = buildHttpRequest(url, v3Request, property);
+        clearLargeData(request, v3Request);
+        HttpUtils.streamRequest(httpRequest, new BellaStreamCallback((Callbacks.HttpStreamTtsCallback) callback));
+    }
+
+    @Override
+    public Callbacks.StreamCallback buildCallback(TtsRequest request, Callbacks.Sender byteSender,
+            EndpointProcessData processData, EndpointLogger logger) {
+        return new HuoShanV3StreamTtsCallback(byteSender, processData, logger);
+    }
+
+    @Override
+    public String getDescription() {
+        return "火山V3协议";
+    }
+
+    @Override
+    public Class<?> getPropertyClass() {
+        return HuoShanV3Property.class;
+    }
+
+    private Request buildHttpRequest(String url, HuoShanV3Request v3Request, HuoShanV3Property property) {
+        return new Request.Builder()
+                .url(url)
+                .header("X-Api-App-Id", property.getAppId())
+                .header("X-Api-Access-Key", property.getAccessKey())
+                .header("X-Api-Resource-Id", property.getResourceId())
+                .header("X-Api-Request-Id", UUID.randomUUID().toString())
+                .post(RequestBody.create(MediaType.parse("application/json"), JacksonUtils.toByte(v3Request)))
+                .build();
+    }
+
+    static HttpStatus mapErrorCode(int code) {
+        if (code == HuoShanV3Response.CODE_TEXT_LIMIT) {
+            return HttpStatus.PAYLOAD_TOO_LARGE;
+        } else if (code == HuoShanV3Response.CODE_PERMISSION) {
+            return HttpStatus.FORBIDDEN;
+        } else if (code == HuoShanV3Response.CODE_SERVER_ERROR) {
+            return HttpStatus.SERVICE_UNAVAILABLE;
+        }
+        return HttpStatus.INTERNAL_SERVER_ERROR;
+    }
+
+    /**
+     * 非流式音频收集器：复用 HuoShanV3StreamTtsCallback 的行解析逻辑，
+     * 通过自定义 Sender 将音频字节收集到 buffer 中。
+     */
+    private static class AudioCollector {
+        private final ByteArrayOutputStream audioBuffer = new ByteArrayOutputStream();
+        private final CompletableFuture<Void> doneFuture = new CompletableFuture<>();
+        private volatile BellaException error;
+
+        private final Callbacks.Sender bufferSender = new Callbacks.Sender() {
+            @Override
+            public void send(String text) {
+            }
+
+            @Override
+            public void send(byte[] bytes) {
+                audioBuffer.write(bytes, 0, bytes.length);
+            }
+
+            @Override
+            public void onError(Throwable e) {
+                error = BellaException.fromException(e);
+            }
+
+            @Override
+            public void close() {
+                doneFuture.complete(null);
+            }
+        };
+
+        private final HuoShanV3StreamTtsCallback delegate = new HuoShanV3StreamTtsCallback(bufferSender, null, null) {
+            @Override
+            public void finish() {
+                // 只做行缓冲刷新和关闭 sender，跳过 metrics 和 logger
+                flushLineBuffer();
+                bufferSender.close();
+            }
+
+            @Override
+            public void finish(BellaException exception) {
+                error = exception;
+                finish();
+            }
+        };
+
+        public HuoShanV3StreamTtsCallback getDelegate() {
+            return delegate;
+        }
+
+        public byte[] getAudioBytes() {
+            try {
+                doneFuture.get(30, TimeUnit.SECONDS);
+            } catch (TimeoutException e) {
+                throw new BellaException.ChannelException(HttpStatus.GATEWAY_TIMEOUT.value(),
+                        HttpStatus.GATEWAY_TIMEOUT.getReasonPhrase(), "TTS request timed out after 30s");
+            } catch (Exception e) {
+                throw BellaException.fromException(e);
+            }
+            if (error != null) {
+                throw error;
+            }
+            byte[] result = audioBuffer.toByteArray();
+            if (result.length == 0) {
+                throw new BellaException.ChannelException(HttpStatus.INTERNAL_SERVER_ERROR.value(),
+                        HttpStatus.INTERNAL_SERVER_ERROR.getReasonPhrase(), "No audio data in response");
+            }
+            return result;
+        }
+    }
+}

--- a/api/server/src/main/java/com/ke/bella/openapi/protocol/tts/HuoShanV3StreamTtsCallback.java
+++ b/api/server/src/main/java/com/ke/bella/openapi/protocol/tts/HuoShanV3StreamTtsCallback.java
@@ -1,0 +1,111 @@
+package com.ke.bella.openapi.protocol.tts;
+
+import java.io.ByteArrayOutputStream;
+import java.util.Base64;
+import java.util.HashMap;
+
+import com.ke.bella.openapi.EndpointProcessData;
+import com.ke.bella.openapi.common.exception.BellaException;
+import com.ke.bella.openapi.protocol.Callbacks;
+import com.ke.bella.openapi.protocol.OpenapiResponse;
+import com.ke.bella.openapi.protocol.log.EndpointLogger;
+import com.ke.bella.openapi.utils.DateTimeUtils;
+import com.ke.bella.openapi.utils.JacksonUtils;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * 火山 V3 HTTP Chunked TTS 流式回调。
+ * 响应格式为每行一个 JSON: {"code":0,"message":"","data":"base64音频"}
+ */
+@Slf4j
+public class HuoShanV3StreamTtsCallback implements Callbacks.HttpStreamTtsCallback {
+
+    private static final Base64.Decoder BASE64_DECODER = Base64.getDecoder();
+
+    private final Callbacks.Sender byteSender;
+    private final EndpointProcessData processData;
+    private final EndpointLogger logger;
+
+    private boolean first = true;
+    private final long startTime = DateTimeUtils.getCurrentMills();
+    private final ByteArrayOutputStream lineBuffer = new ByteArrayOutputStream();
+
+    public HuoShanV3StreamTtsCallback(Callbacks.Sender byteSender, EndpointProcessData processData, EndpointLogger logger) {
+        this.byteSender = byteSender;
+        this.processData = processData;
+        this.logger = logger;
+        processData.setMetrics(new HashMap<>());
+    }
+
+    @Override
+    public void onOpen() {
+    }
+
+    @Override
+    public void callback(byte[] msg) {
+        for (byte b : msg) {
+            if (b == '\n') {
+                processLine();
+                lineBuffer.reset();
+            } else {
+                lineBuffer.write(b);
+            }
+        }
+    }
+
+    private void processLine() {
+        if (lineBuffer.size() == 0) {
+            return;
+        }
+        String line = lineBuffer.toString().trim();
+        if (line.isEmpty() || !line.startsWith("{")) {
+            return;
+        }
+        try {
+            HuoShanV3Response response = JacksonUtils.deserialize(line, HuoShanV3Response.class);
+            if (response == null) {
+                return;
+            }
+            if (!response.isSuccess()) {
+                log.warn("HuoShanV3 stream error: code={}, message={}", response.getCode(), response.getMessage());
+                HttpStatus status = HuoShanV3Adaptor.mapErrorCode(response.getCode());
+                finish(new BellaException.ChannelException(status.value(), status.getReasonPhrase(), response.getMessage()));
+                return;
+            }
+            if (response.getData() != null && !response.getData().isEmpty()) {
+                byte[] audioBytes = BASE64_DECODER.decode(response.getData());
+                byteSender.send(audioBytes);
+                if (first) {
+                    processData.getMetrics().put("ttft", DateTimeUtils.getCurrentMills() - startTime);
+                    first = false;
+                }
+            }
+        } catch (Exception e) {
+            log.error("Failed to parse HuoShanV3 data: {}", line, e);
+        }
+    }
+
+    protected void flushLineBuffer() {
+        if (lineBuffer.size() > 0) {
+            processLine();
+            lineBuffer.reset();
+        }
+    }
+
+    @Override
+    public void finish() {
+        flushLineBuffer();
+        processData.getMetrics().put("ttlt", DateTimeUtils.getCurrentMills() - startTime);
+        byteSender.close();
+        logger.log(processData);
+    }
+
+    @Override
+    public void finish(BellaException exception) {
+        processData.setResponse(OpenapiResponse.errorResponse(exception.convertToOpenapiError()));
+        finish();
+    }
+}


### PR DESCRIPTION
## Summary
- 新增火山引擎 V3 HTTP Chunked 流式 TTS 适配器，对接 `openspeech.bytedance.com/api/v3/tts/unidirectional` 接口
- 支持流式和非流式 TTS，使用 `X-Api-*` 自定义 Header 认证
- 通过 `BellaStreamCallback` 实现 HTTP Chunked 逐行 JSON 解析和 base64 音频解码

## 新增文件
- `HuoShanV3Property.java` — channel 配置 DTO（appId, accessKey, resourceId）
- `HuoShanV3Request.java` — V3 请求体结构，支持 extra_body 透传
- `HuoShanV3Response.java` — V3 响应体，含错误码映射
- `HuoShanV3Adaptor.java` — TTS 适配器（Component: `HuoShanV3Tts`）
- `HuoShanV3StreamTtsCallback.java` — 流式回调，按行拆分 JSON 并解码音频

🤖 Generated with [Claude Code](https://claude.com/claude-code)