### PR TITLE
feat(responses-api): support converting system role to developer role

### DIFF
--- a/api/sdk/src/main/java/com/ke/bella/openapi/protocol/completion/ResponsesApiProperty.java
+++ b/api/sdk/src/main/java/com/ke/bella/openapi/protocol/completion/ResponsesApiProperty.java
@@ -20,10 +20,13 @@ public class ResponsesApiProperty extends CompletionProperty {
 
     String apiVersion;
 
+    boolean convertSystemToDeveloper;
+
     @Override
     public Map<String, String> description() {
         Map<String, String> map = super.description();
         map.put("apiVersion", "API版本(url中需要拼接时填写)");
+        map.put("convertSystemToDeveloper", "是否将system role转换为developer role");
         return map;
     }
 }

--- a/api/server/src/main/java/com/ke/bella/openapi/protocol/completion/ResponsesApiAdaptor.java
+++ b/api/server/src/main/java/com/ke/bella/openapi/protocol/completion/ResponsesApiAdaptor.java
@@ -37,7 +37,7 @@ public class ResponsesApiAdaptor implements CompletionAdaptor<ResponsesApiProper
 
         // 转换请求格式
         ResponsesApiRequest responsesRequest = ResponsesApiConverter.convertChatCompletionToResponses(request,
-                EndpointContext.getProcessData().getAkCode());
+                EndpointContext.getProcessData().getAkCode(), property);
 
         // 构建HTTP请求
         Request httpRequest = buildResponsesApiRequest(responsesRequest, url, property);
@@ -64,7 +64,7 @@ public class ResponsesApiAdaptor implements CompletionAdaptor<ResponsesApiProper
 
         // 转换请求格式
         ResponsesApiRequest responsesRequest = ResponsesApiConverter.convertChatCompletionToResponses(request,
-                EndpointContext.getProcessData().getAkCode());
+                EndpointContext.getProcessData().getAkCode(), property);
         responsesRequest.setStream(true);  // 确保启用流式
 
         // 创建 SSE 转换器和监听器

--- a/api/server/src/main/java/com/ke/bella/openapi/protocol/completion/ResponsesApiConverter.java
+++ b/api/server/src/main/java/com/ke/bella/openapi/protocol/completion/ResponsesApiConverter.java
@@ -1,6 +1,5 @@
 package com.ke.bella.openapi.protocol.completion;
 
-import com.ke.bella.openapi.utils.JacksonUtils;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -17,10 +16,10 @@ public class ResponsesApiConverter {
 
     /**
      * 将 Chat Completion 请求转换为 Responses API 请求
-     * 
+     *
      * @return Responses API 请求
      */
-    public static ResponsesApiRequest convertChatCompletionToResponses(CompletionRequest chatRequest, String akCode) {
+    public static ResponsesApiRequest convertChatCompletionToResponses(CompletionRequest chatRequest, String akCode, ResponsesApiProperty property) {
         ResponsesApiRequest.ResponsesApiRequestBuilder builder = ResponsesApiRequest.builder();
 
         // 基本参数映射
@@ -34,7 +33,7 @@ public class ResponsesApiConverter {
                 .previous_response_id(null);
 
         // 转换消息列表为 input 数组
-        List<ResponsesApiRequest.InputItem> inputItems = convertMessagesToInput(chatRequest.getMessages());
+        List<ResponsesApiRequest.InputItem> inputItems = convertMessagesToInput(chatRequest.getMessages(), property.isConvertSystemToDeveloper());
         builder.input(inputItems);
 
         // 转换工具定义
@@ -63,7 +62,7 @@ public class ResponsesApiConverter {
     /**
      * 将消息列表转换为 Responses API 的 input 格式
      */
-    private static List<ResponsesApiRequest.InputItem> convertMessagesToInput(List<Message> messages) {
+    private static List<ResponsesApiRequest.InputItem> convertMessagesToInput(List<Message> messages, boolean convertSystemToDeveloper) {
         if(CollectionUtils.isEmpty(messages)) {
             return Collections.emptyList();
         }
@@ -93,10 +92,10 @@ public class ResponsesApiConverter {
                     inputItems.add(callItem);
                 }
             } else {
-                // 普通消息转换
+                String role = convertSystemToDeveloper && "system".equals(message.getRole()) ? "developer" : message.getRole();
                 ResponsesApiRequest.InputItem messageItem = ResponsesApiRequest.InputItem.builder()
                         .type("message")
-                        .role(message.getRole())
+                        .role(role)
                         .content(convertMessageContent(message))
                         .build();
                 if(messageItem.getContent() != null) {
@@ -180,9 +179,9 @@ public class ResponsesApiConverter {
 
     /**
      * 将 Responses API 响应转换为 Chat Completion 响应
-     * 
+     *
      * @param responsesResponse Responses API 响应
-     * 
+     *
      * @return Chat Completion 响应
      */
     public static CompletionResponse convertResponsesToChatCompletion(ResponsesApiResponse responsesResponse) {


### PR DESCRIPTION
Add `convertSystemToDeveloper` property to `ResponsesApiProperty` to allow mapping `role=system` messages to `role=developer` when calling upstream Responses API endpoints that do not accept the system role.