### PR TITLE
feat(#644): 离线转录接口支持字段透传

### DIFF
--- a/api/server/src/main/java/com/ke/bella/openapi/protocol/asr/AudioTranscriptionRequest.java
+++ b/api/server/src/main/java/com/ke/bella/openapi/protocol/asr/AudioTranscriptionRequest.java
@@ -1,10 +1,15 @@
 package com.ke.bella.openapi.protocol.asr;
 
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 
 import javax.validation.constraints.NotEmpty;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public class AudioTranscriptionRequest {
     @Data
@@ -170,6 +175,22 @@ public class AudioTranscriptionRequest {
 
         @JsonProperty("ssd_version")
         private String ssdVersion;
+
+        @JsonIgnore
+        private Map<String, Object> extraBody;
+
+        @JsonAnyGetter
+        public Map<String, Object> getExtraBodyFields() {
+            return extraBody != null && !extraBody.isEmpty() ? extraBody : null;
+        }
+
+        @JsonAnySetter
+        public void setExtraBodyField(String key, Object value) {
+            if (extraBody == null) {
+                extraBody = new HashMap<>();
+            }
+            extraBody.put(key, value);
+        }
     }
 
     @Data


### PR DESCRIPTION
## 变更概述

为离线转录接口 `/v1/audio/transcriptions/file` 的请求 DTO `AudioTranscriptionReq` 添加 `@JsonAnySetter/@JsonAnyGetter` 字段透传能力，使未定义的 JSON 字段能被自动捕获并在序列化时透传给下游 worker。

## 变更详情

| 文件 | 改动类型 | 说明 |
|------|----------|------|
| `server/.../asr/AudioTranscriptionRequest.java` | 修改 | 添加 `extra_body` 字段及 `@JsonAnySetter/@JsonAnyGetter` 透传支持 |

## 关联 Issue
Closes LianjiaTech/bella-openapi#644

## 测试验证
- [ ] 向 `/v1/audio/transcriptions/file` 发送含未定义字段的请求，验证不报错
- [ ] 验证额外字段在序列化后被保留透传
- [ ] 验证现有已定义字段行为不变

## 风险说明
无特殊风险

## 部署注意
无