### PR TITLE
feat:增强分配给我的密钥ID展示与复制能力

### DIFF
--- a/web_v2/src/app/[locale]/(dashboard)/manager/components/ManagedKeysTable.tsx
+++ b/web_v2/src/app/[locale]/(dashboard)/manager/components/ManagedKeysTable.tsx
@@ -321,7 +321,7 @@ function AssignedSection({ managerCode, onCopy, onReset, onCountChange, refreshT
                 <TableHeader>
                     <TableRow>
                         <TableHead>密钥代码</TableHead>
-                        <TableHead>所属密钥</TableHead>
+                        <TableHead>密钥ID</TableHead>
                         <TableHead>名称</TableHead>
                         <TableHead>服务名</TableHead>
                         <TableHead>月配额</TableHead>
@@ -345,11 +345,30 @@ function AssignedSection({ managerCode, onCopy, onReset, onCountChange, refreshT
                             <TableCell className="text-xs">
                                 <span className="truncate max-w-[150px] block" title={apiKey.akDisplay}>{apiKey.akDisplay}</span>
                             </TableCell>
-                            {/* 父AK code：帮助用户知道这个子AK属于哪个组织 */}
+                            {/* AK code：帮助用户知道这个子AK的akcode */}
                             <TableCell className="text-xs">
-                                <span className="truncate max-w-[120px] block text-muted-foreground" title={apiKey.parentCode}>
-                                    {apiKey.parentCode || '-'}
-                                </span>
+                                {apiKey.code ? (
+                                    <div className="inline-flex max-w-[160px] items-center gap-1.5 rounded-md border bg-muted/40 px-2 py-1 align-middle">
+                                        <span
+                                            className="min-w-0 flex-1 overflow-x-auto whitespace-nowrap font-mono text-xs text-foreground [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden"
+                                            title={apiKey.code}
+                                        >
+                                            {apiKey.code}
+                                        </span>
+                                        <Button
+                                            type="button"
+                                            variant="ghost"
+                                            size="sm"
+                                            className="h-5 w-5 shrink-0 p-0 text-muted-foreground hover:text-foreground"
+                                            onClick={() => onCopy(apiKey.code)}
+                                            aria-label={`复制密钥ID ${apiKey.code}`}
+                                        >
+                                            <Copy className="h-3.5 w-3.5" />
+                                        </Button>
+                                    </div>
+                                ) : (
+                                    <span className="text-muted-foreground">-</span>
+                                )}
                             </TableCell>
                             <TableCell className="text-sm">{apiKey.name || '-'}</TableCell>
                             <TableCell className="text-sm">{apiKey.serviceId || '-'}</TableCell>
@@ -379,7 +398,7 @@ function AssignedSection({ managerCode, onCopy, onReset, onCountChange, refreshT
                                                 onClick={() => onCopy(apiKey.code)}
                                             >
                                                 <Copy className="h-4 w-4" />
-                                                复制密钥编码
+                                                复制密钥ID
                                             </button>
                                         </div>
                                     </PopoverContent>


### PR DESCRIPTION
## 变更概述
调整“分配给我的”列表中的密钥展示方式，将第二列从“所属密钥”改为“密钥ID”，并补充列内复制能力，方便直接查看和复制当前子密钥 code。

## 变更详情

| 文件 | 改动类型 | 说明 |
|------|----------|------|
| web_v2/src/app/[locale]/(dashboard)/manager/components/ManagedKeysTable.tsx | 修改 | 将第二列改为展示 ，新增列内复制按钮，并同步更新操作菜单文案 |

## 关联 Issue
Closes LianjiaTech/bella-openapi#643

## 测试验证
- [ ] 在“分配给我的”列表确认第二列显示为密钥ID
- [ ] 点击列内复制按钮，确认复制结果为当前行 
- [ ] 点击操作菜单“复制密钥ID”，确认复制结果一致

## 风险说明
仅涉及前端展示与复制交互调整，无后端接口变更。

## 部署注意
无