### PR TITLE
feat(#629): Gemini 适配层支持 Google Search grounding 工具

### DIFF
--- a/api/sdk/src/main/java/com/ke/bella/openapi/protocol/completion/CompletionPriceInfo.java
+++ b/api/sdk/src/main/java/com/ke/bella/openapi/protocol/completion/CompletionPriceInfo.java
@@ -22,12 +22,14 @@ public class CompletionPriceInfo implements IPriceInfo, Serializable {
     private String unit = "分/千token";
     private double batchDiscount = 1.0;
     private List<Tier> tiers;
+    private Map<String, BigDecimal> toolPrices;
 
     @Override
     public Map<String, String> description() {
         Map<String, String> map = new LinkedHashMap<>();
         map.put("batchDiscount", "批量折扣");
         map.put("tiers", "区间价格列表");
+        map.put("toolPrices", "工具调用价格配置(Map<工具名,单价(分/次)>,可选),如:{\"web_search\":0.035}");
         return map;
     }
 

--- a/api/sdk/src/main/java/com/ke/bella/openapi/protocol/completion/CompletionResponse.java
+++ b/api/sdk/src/main/java/com/ke/bella/openapi/protocol/completion/CompletionResponse.java
@@ -13,7 +13,9 @@ import org.apache.commons.collections4.CollectionUtils;
 import org.springframework.util.Assert;
 
 import java.io.Serializable;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 @Data
 @JsonInclude(Include.NON_NULL)
@@ -108,6 +110,7 @@ public class CompletionResponse extends OpenapiResponse {
         private int index;
         private Message message;
         private Logprobs logprobs;
+        private Object grounding_metadata;
 
         public String content() {
             if(message != null && message.getContent() != null) {
@@ -171,11 +174,18 @@ public class CompletionResponse extends OpenapiResponse {
         private int cache_read_tokens;
         private TokensDetail completion_tokens_details;
         private TokensDetail prompt_tokens_details;
+        private Map<String, Integer> tool_usage;
 
         public TokenUsage add(TokenUsage u) {
             this.completion_tokens += u.completion_tokens;
             this.prompt_tokens += u.prompt_tokens;
             this.total_tokens += u.total_tokens;
+            if(u.tool_usage != null) {
+                if(this.tool_usage == null) {
+                    this.tool_usage = new HashMap<>();
+                }
+                u.tool_usage.forEach((k, v) -> this.tool_usage.merge(k, v, Integer::sum));
+            }
             return this;
         }
 

--- a/api/sdk/src/main/java/com/ke/bella/openapi/protocol/completion/Message.java
+++ b/api/sdk/src/main/java/com/ke/bella/openapi/protocol/completion/Message.java
@@ -1,5 +1,8 @@
 package com.ke.bella.openapi.protocol.completion;
 
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -13,7 +16,9 @@ import javax.annotation.Nullable;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 import java.io.Serializable;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 @Data
@@ -128,6 +133,21 @@ public class Message implements Serializable {
         private String type;
         private Function function;
         private Object cache_control;
+        @JsonIgnore
+        private Map<String, Object> extraBody;
+
+        @JsonAnyGetter
+        public Map<String, Object> getExtraBodyFields() {
+            return extraBody != null && !extraBody.isEmpty() ? extraBody : null;
+        }
+
+        @JsonAnySetter
+        public void setExtraBodyField(String key, Object value) {
+            if (extraBody == null) {
+                extraBody = new HashMap<>();
+            }
+            extraBody.put(key, value);
+        }
     }
 
     @Data

--- a/api/sdk/src/main/java/com/ke/bella/openapi/protocol/completion/StreamCompletionResponse.java
+++ b/api/sdk/src/main/java/com/ke/bella/openapi/protocol/completion/StreamCompletionResponse.java
@@ -126,6 +126,7 @@ public class StreamCompletionResponse extends OpenapiResponse {
         private int index;
         private Message delta;
         private CompletionResponse.Logprobs logprobs;
+        private Object grounding_metadata;
 
         public String content() {
             if(delta != null && delta.getContent() != null) {

--- a/api/sdk/src/main/java/com/ke/bella/openapi/protocol/completion/VertexProperty.java
+++ b/api/sdk/src/main/java/com/ke/bella/openapi/protocol/completion/VertexProperty.java
@@ -1,13 +1,10 @@
 package com.ke.bella.openapi.protocol.completion;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.ke.bella.openapi.protocol.AuthorizationProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.Map;
 
 @Data

--- a/api/server/src/main/java/com/ke/bella/openapi/protocol/completion/VertexConverter.java
+++ b/api/server/src/main/java/com/ke/bella/openapi/protocol/completion/VertexConverter.java
@@ -8,6 +8,7 @@ import com.ke.bella.openapi.protocol.completion.gemini.FunctionResponse;
 import com.ke.bella.openapi.protocol.completion.gemini.GeminiRequest;
 import com.ke.bella.openapi.protocol.completion.gemini.GeminiResponse;
 import com.ke.bella.openapi.protocol.completion.gemini.GenerationConfig;
+import com.ke.bella.openapi.protocol.completion.gemini.GroundingMetadata;
 import com.ke.bella.openapi.protocol.completion.gemini.LogprobsResult;
 import com.ke.bella.openapi.protocol.completion.gemini.Part;
 import com.ke.bella.openapi.protocol.completion.gemini.SystemInstruction;
@@ -61,6 +62,17 @@ public class VertexConverter {
             builder.tools(tools);
         }
 
+        // Handle toolConfig from extra_body
+        Map<String, Object> extraBody = openaiRequest.getExtra_body();
+        if(MapUtils.isNotEmpty(extraBody) && extraBody.containsKey("toolConfig")) {
+            Object toolConfigObj = extraBody.get("toolConfig");
+            if(toolConfigObj instanceof Map) {
+                @SuppressWarnings("unchecked")
+                Map<String, Object> toolConfig = (Map<String, Object>) toolConfigObj;
+                builder.toolConfig(toolConfig);
+            }
+        }
+
         // Convert generation config
         GenerationConfig generationConfig = convertGenerationConfig(openaiRequest, property);
         builder.generationConfig(generationConfig);
@@ -96,7 +108,7 @@ public class VertexConverter {
         }
 
         // Convert usage
-        CompletionResponse.TokenUsage usage = convertUsage(vertexResponse.getUsageMetadata());
+        CompletionResponse.TokenUsage usage = convertUsage(vertexResponse.getUsageMetadata(), vertexResponse.getCandidates());
 
         return CompletionResponse.builder()
                 .id(vertexResponse.getResponseId())
@@ -139,7 +151,7 @@ public class VertexConverter {
 
         // 处理 usage metadata
         if(geminiResponse.getUsageMetadata() != null && isFinal) {
-            builder.usage(VertexConverter.convertUsage(geminiResponse.getUsageMetadata()));
+            builder.usage(VertexConverter.convertUsage(geminiResponse.getUsageMetadata(), geminiResponse.getCandidates()));
         }
 
         return builder.build();
@@ -327,7 +339,21 @@ public class VertexConverter {
     }
 
     private static List<Tool> convertTools(List<Message.Tool> openaiTools) {
+        Map<String, Object> googleSearch = null;
+        for (Message.Tool tool : openaiTools) {
+            Map<String, Object> extraBodyFields = tool.getExtraBodyFields();
+            if(extraBodyFields != null && extraBodyFields.containsKey("google_search")) {
+                Object googleSearchObj = extraBodyFields.get("google_search");
+                @SuppressWarnings("unchecked")
+                Map<String, Object> parsed = (googleSearchObj instanceof Map)
+                        ? (Map<String, Object>) googleSearchObj : Collections.emptyMap();
+                googleSearch = parsed;
+                break;
+            }
+        }
+
         List<Tool.FunctionDeclaration> functionDeclarations = openaiTools.stream()
+                .filter(tool -> tool.getFunction() != null)
                 .map(tool -> {
                     Message.Function function = tool.getFunction();
                     return Tool.FunctionDeclaration.builder()
@@ -338,8 +364,14 @@ public class VertexConverter {
                 })
                 .collect(Collectors.toList());
 
-        return Collections.singletonList(
-                Tool.builder().functionDeclarations(functionDeclarations).build());
+        Tool.ToolBuilder toolBuilder = Tool.builder();
+        if(googleSearch != null) {
+            toolBuilder.googleSearch(googleSearch);
+        }
+        if(!functionDeclarations.isEmpty()) {
+            toolBuilder.functionDeclarations(functionDeclarations);
+        }
+        return Collections.singletonList(toolBuilder.build());
     }
 
     private static GenerationConfig convertGenerationConfig(CompletionRequest request, VertexProperty property) {
@@ -411,6 +443,7 @@ public class VertexConverter {
                 .message(message)
                 .finish_reason(finishReason)
                 .logprobs(convertLogprobs(candidate.getLogprobsResult()))
+                .grounding_metadata(candidate.getGroundingMetadata())
                 .build();
     }
 
@@ -423,6 +456,7 @@ public class VertexConverter {
                 .delta(delta)
                 .finish_reason(finishReason)
                 .logprobs(convertLogprobs(candidate.getLogprobsResult()))
+                .grounding_metadata(candidate.getGroundingMetadata())
                 .build();
     }
 
@@ -552,7 +586,7 @@ public class VertexConverter {
         return builder.build();
     }
 
-    public static CompletionResponse.TokenUsage convertUsage(UsageMetadata usageMetadata) {
+    public static CompletionResponse.TokenUsage convertUsage(UsageMetadata usageMetadata, List<Candidate> candidates) {
         if(usageMetadata == null) {
             return null;
         }
@@ -621,6 +655,24 @@ public class VertexConverter {
                     }
                 }
             });
+        }
+
+        // Extract tool_usage from grounding metadata (web_search count)
+        if(CollectionUtils.isNotEmpty(candidates)) {
+            Map<String, Integer> toolUsage = null;
+            for (Candidate candidate : candidates) {
+                GroundingMetadata groundingMetadata = candidate.getGroundingMetadata();
+                if(groundingMetadata != null && CollectionUtils.isNotEmpty(groundingMetadata.getWebSearchQueries())) {
+                    if(toolUsage == null) {
+                        toolUsage = new HashMap<>();
+                    }
+                    int current = toolUsage.getOrDefault("web_search", 0);
+                    toolUsage.put("web_search", current + groundingMetadata.getWebSearchQueries().size());
+                }
+            }
+            if(toolUsage != null) {
+                builder.tool_usage(toolUsage);
+            }
         }
 
         return builder.build();

--- a/api/server/src/main/java/com/ke/bella/openapi/protocol/completion/callback/MergeReasoningCallback.java
+++ b/api/server/src/main/java/com/ke/bella/openapi/protocol/completion/callback/MergeReasoningCallback.java
@@ -61,7 +61,7 @@ public class MergeReasoningCallback extends Callbacks.StreamCompletionCallbackNo
         } else if(stage == 3) {
             message.setContent("\n```\n" + (thinkMessage.getContent() == null ? "" : thinkMessage.getContent()));
         }
-        response.getChoices().add(new StreamCompletionResponse.Choice("", 0, message, null));
+        response.getChoices().add(new StreamCompletionResponse.Choice("", 0, message, null, null));
         response.setStandardFormat(resp);
         return response;
     }

--- a/api/server/src/main/java/com/ke/bella/openapi/protocol/completion/gemini/Candidate.java
+++ b/api/server/src/main/java/com/ke/bella/openapi/protocol/completion/gemini/Candidate.java
@@ -21,4 +21,5 @@ public class Candidate {
     private Double avgLogprobs;
     private LogprobsResult logprobsResult;
     private Integer index;
+    private GroundingMetadata groundingMetadata;
 }

--- a/api/server/src/main/java/com/ke/bella/openapi/protocol/completion/gemini/GeminiRequest.java
+++ b/api/server/src/main/java/com/ke/bella/openapi/protocol/completion/gemini/GeminiRequest.java
@@ -11,6 +11,7 @@ import lombok.NoArgsConstructor;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 @Data
 @Builder
@@ -23,6 +24,7 @@ public class GeminiRequest implements IMemoryClearable, ITransfer {
     private List<Tool> tools;
     private List<SafetySetting> safetySettings;
     private GenerationConfig generationConfig;
+    private Map<String, Object> toolConfig;
 
     // 关闭所有安全审核策略
     public GeminiRequest offSafetySettings() {
@@ -60,6 +62,7 @@ public class GeminiRequest implements IMemoryClearable, ITransfer {
             this.safetySettings = null;
             this.systemInstruction = null;
             this.generationConfig = null;
+            this.toolConfig = null;
 
             // 标记为已清理
             this.cleared = true;

--- a/api/server/src/main/java/com/ke/bella/openapi/protocol/completion/gemini/GroundingMetadata.java
+++ b/api/server/src/main/java/com/ke/bella/openapi/protocol/completion/gemini/GroundingMetadata.java
@@ -1,0 +1,71 @@
+package com.ke.bella.openapi.protocol.completion.gemini;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class GroundingMetadata {
+    private List<String> webSearchQueries;
+    private SearchEntryPoint searchEntryPoint;
+    private List<GroundingChunk> groundingChunks;
+    private List<GroundingSupport> groundingSupports;
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class SearchEntryPoint {
+        private String renderedContent;
+    }
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class GroundingChunk {
+        private Web web;
+
+        @Data
+        @Builder
+        @NoArgsConstructor
+        @AllArgsConstructor
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        public static class Web {
+            private String uri;
+            private String title;
+        }
+    }
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class GroundingSupport {
+        private Segment segment;
+        private List<Integer> groundingChunkIndices;
+        private List<Double> confidenceScores;
+    }
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class Segment {
+        private Integer startIndex;
+        private Integer endIndex;
+        private String text;
+    }
+}

--- a/api/server/src/main/java/com/ke/bella/openapi/protocol/completion/gemini/Tool.java
+++ b/api/server/src/main/java/com/ke/bella/openapi/protocol/completion/gemini/Tool.java
@@ -1,6 +1,7 @@
 package com.ke.bella.openapi.protocol.completion.gemini;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.ke.bella.openapi.protocol.completion.Message;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -18,6 +19,8 @@ import java.util.Map;
 public class Tool {
     private List<FunctionDeclaration> functionDeclarations;
     private Map<String, Object> codeExecution;
+    @JsonProperty("google_search")
+    private Map<String, Object> googleSearch;
 
     @Data
     @Builder

--- a/api/server/src/main/java/com/ke/bella/openapi/protocol/cost/CostCalculator.java
+++ b/api/server/src/main/java/com/ke/bella/openapi/protocol/cost/CostCalculator.java
@@ -139,10 +139,16 @@ public class CostCalculator {
                         .cost(completionCost).build());
             }
 
+            Map<String, CostDetails.ToolCostDetailItem> toolDetails = new HashMap<>();
+            if(price.getToolPrices() != null && tokenUsage.getTool_usage() != null) {
+                totalCost = totalCost.add(calculateToolCost(price.getToolPrices(), tokenUsage.getTool_usage(), toolDetails));
+            }
+
             return CostDetails.builder()
                     .totalCost(totalCost)
                     .inputDetails(inputDetails.isEmpty() ? null : inputDetails)
                     .outputDetails(outputDetails.isEmpty() ? null : outputDetails)
+                    .toolDetails(toolDetails.isEmpty() ? null : toolDetails)
                     .build();
         }
 
@@ -603,31 +609,7 @@ public class CostCalculator {
                 Map<String, BigDecimal> toolPrices,
                 Map<String, Integer> toolUsage,
                 Map<String, CostDetails.ToolCostDetailItem> toolDetails) {
-            BigDecimal toolCost = BigDecimal.ZERO;
-
-            if(toolUsage == null || toolUsage.isEmpty()) {
-                return toolCost;
-            }
-
-            for(Map.Entry<String, Integer> entry : toolUsage.entrySet()) {
-                String toolName = entry.getKey();
-                Integer count = entry.getValue();
-
-                if(count == null || count == 0) {
-                    continue;
-                }
-
-                BigDecimal unitPrice = toolPrices.get(toolName);
-                if(unitPrice != null) {
-                    BigDecimal cost = unitPrice.multiply(BigDecimal.valueOf(count));
-                    toolCost = toolCost.add(cost);
-                    toolDetails.put(toolName, CostDetails.ToolCostDetailItem.builder()
-                            .callCount(count).unitPrice(unitPrice)
-                            .cost(cost).build());
-                }
-            }
-
-            return toolCost;
+            return CostCalculator.calculateToolCost(toolPrices, toolUsage, toolDetails);
         }
 
         @Override
@@ -639,6 +621,37 @@ public class CostCalculator {
             return price.validate();
         }
     };
+
+    static BigDecimal calculateToolCost(
+            Map<String, BigDecimal> toolPrices,
+            Map<String, Integer> toolUsage,
+            Map<String, CostDetails.ToolCostDetailItem> toolDetails) {
+        BigDecimal toolCost = BigDecimal.ZERO;
+
+        if(toolUsage == null || toolUsage.isEmpty()) {
+            return toolCost;
+        }
+
+        for(Map.Entry<String, Integer> entry : toolUsage.entrySet()) {
+            String toolName = entry.getKey();
+            Integer count = entry.getValue();
+
+            if(count == null || count == 0) {
+                continue;
+            }
+
+            BigDecimal unitPrice = toolPrices.get(toolName);
+            if(unitPrice != null) {
+                BigDecimal cost = unitPrice.multiply(BigDecimal.valueOf(count));
+                toolCost = toolCost.add(cost);
+                toolDetails.put(toolName, CostDetails.ToolCostDetailItem.builder()
+                        .callCount(count).unitPrice(unitPrice)
+                        .cost(cost).build());
+            }
+        }
+
+        return toolCost;
+    }
 
     interface EndpointCostCalculator {
         CostDetails calculate(String priceInfo, Object usage);

--- a/api/server/src/main/java/com/ke/bella/openapi/protocol/gemini/VertexAdaptor.java
+++ b/api/server/src/main/java/com/ke/bella/openapi/protocol/gemini/VertexAdaptor.java
@@ -7,9 +7,11 @@ import com.ke.bella.openapi.common.exception.BellaException;
 import com.ke.bella.openapi.protocol.completion.CompletionResponse;
 import com.ke.bella.openapi.protocol.completion.VertexConverter;
 import com.ke.bella.openapi.protocol.completion.VertexProperty;
+import com.ke.bella.openapi.protocol.completion.gemini.Candidate;
 import com.ke.bella.openapi.protocol.completion.gemini.Content;
 import com.ke.bella.openapi.protocol.completion.gemini.GeminiRequest;
 import com.ke.bella.openapi.protocol.completion.gemini.GeminiResponse;
+import com.ke.bella.openapi.protocol.completion.gemini.GroundingMetadata;
 import com.ke.bella.openapi.protocol.completion.gemini.Part;
 import com.ke.bella.openapi.protocol.log.EndpointLogger;
 import com.ke.bella.openapi.utils.HttpUtils;
@@ -29,6 +31,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Vertex Gemini 适配器
@@ -201,6 +205,7 @@ public class VertexAdaptor implements GeminiAdaptor<VertexProperty> {
         CompletionResponse finalResponse = new CompletionResponse();
         StringBuilder fullContent = new StringBuilder();
         CompletionResponse.TokenUsage finalUsage = null;
+        GroundingMetadata lastGroundingMetadata = null;
 
         try (java.io.BufferedReader reader = new java.io.BufferedReader(new java.io.StringReader(responseStr))) {
             String line;
@@ -217,13 +222,17 @@ public class VertexAdaptor implements GeminiAdaptor<VertexProperty> {
                         GeminiResponse chunk = JacksonUtils.deserialize(jsonData, GeminiResponse.class);
                         if (chunk != null) {
                             if (chunk.getCandidates() != null && !chunk.getCandidates().isEmpty()) {
-                                Content content = chunk.getCandidates().get(0).getContent();
+                                Candidate candidate = chunk.getCandidates().get(0);
+                                Content content = candidate.getContent();
                                 if (content != null && content.getParts() != null) {
                                     for (Part part : content.getParts()) {
                                         if (part.getText() != null) {
                                             fullContent.append(part.getText());
                                         }
                                     }
+                                }
+                                if (candidate.getGroundingMetadata() != null) {
+                                    lastGroundingMetadata = candidate.getGroundingMetadata();
                                 }
                             }
                             if (chunk.getUsageMetadata() != null) {
@@ -242,11 +251,23 @@ public class VertexAdaptor implements GeminiAdaptor<VertexProperty> {
             log.error("Failed to parse SSE response", e);
         }
 
+        // Populate tool_usage from grounding metadata
+        if (finalUsage != null && lastGroundingMetadata != null
+                && lastGroundingMetadata.getWebSearchQueries() != null
+                && !lastGroundingMetadata.getWebSearchQueries().isEmpty()) {
+            Map<String, Integer> toolUsage = new HashMap<>();
+            toolUsage.put("web_search", lastGroundingMetadata.getWebSearchQueries().size());
+            finalUsage.setTool_usage(toolUsage);
+        }
+
         CompletionResponse.Choice choice = new CompletionResponse.Choice();
         com.ke.bella.openapi.protocol.completion.Message msg = new com.ke.bella.openapi.protocol.completion.Message();
         msg.setRole("assistant");
         msg.setContent(fullContent.toString());
         choice.setMessage(msg);
+        if (lastGroundingMetadata != null) {
+            choice.setGrounding_metadata(lastGroundingMetadata);
+        }
 
         finalResponse.setChoices(Collections.singletonList(choice));
         finalResponse.setUsage(finalUsage);

--- a/api/server/src/test/java/com/ke/bella/openapi/protocol/completion/VertexConverterTest.java
+++ b/api/server/src/test/java/com/ke/bella/openapi/protocol/completion/VertexConverterTest.java
@@ -17,7 +17,7 @@ class VertexConverterTest {
 
 	@Test
 	void testConvertUsage_WithNull_ShouldReturnNull() {
-		CompletionResponse.TokenUsage result = VertexConverter.convertUsage(null);
+		CompletionResponse.TokenUsage result = VertexConverter.convertUsage(null, null);
 
 		assertNull(result);
 	}
@@ -30,7 +30,7 @@ class VertexConverterTest {
 				.totalTokenCount(150)
 				.build();
 
-		CompletionResponse.TokenUsage result = VertexConverter.convertUsage(metadata);
+		CompletionResponse.TokenUsage result = VertexConverter.convertUsage(metadata, null);
 
 		assertNotNull(result);
 		assertEquals(100, result.getPrompt_tokens());
@@ -50,7 +50,7 @@ class VertexConverterTest {
 				.cachedContentTokenCount(30)
 				.build();
 
-		CompletionResponse.TokenUsage result = VertexConverter.convertUsage(metadata);
+		CompletionResponse.TokenUsage result = VertexConverter.convertUsage(metadata, null);
 
 		assertNotNull(result);
 		assertEquals(100, result.getPrompt_tokens());
@@ -70,7 +70,7 @@ class VertexConverterTest {
 				.cachedContentTokenCount(0)
 				.build();
 
-		CompletionResponse.TokenUsage result = VertexConverter.convertUsage(metadata);
+		CompletionResponse.TokenUsage result = VertexConverter.convertUsage(metadata, null);
 
 		assertNotNull(result);
 		assertEquals(0, result.getCache_read_tokens());
@@ -97,7 +97,7 @@ class VertexConverterTest {
 				.promptTokensDetails(promptDetails)
 				.build();
 
-		CompletionResponse.TokenUsage result = VertexConverter.convertUsage(metadata);
+		CompletionResponse.TokenUsage result = VertexConverter.convertUsage(metadata, null);
 
 		assertNotNull(result);
 		assertNotNull(result.getPrompt_tokens_details());
@@ -121,7 +121,7 @@ class VertexConverterTest {
 				.promptTokensDetails(promptDetails)
 				.build();
 
-		CompletionResponse.TokenUsage result = VertexConverter.convertUsage(metadata);
+		CompletionResponse.TokenUsage result = VertexConverter.convertUsage(metadata, null);
 
 		assertNotNull(result);
 		assertNotNull(result.getPrompt_tokens_details());
@@ -157,7 +157,7 @@ class VertexConverterTest {
 				.promptTokensDetails(promptDetails)
 				.build();
 
-		CompletionResponse.TokenUsage result = VertexConverter.convertUsage(metadata);
+		CompletionResponse.TokenUsage result = VertexConverter.convertUsage(metadata, null);
 
 		assertNotNull(result);
 		assertNotNull(result.getPrompt_tokens_details());
@@ -182,7 +182,7 @@ class VertexConverterTest {
 				.promptTokensDetails(promptDetails)
 				.build();
 
-		CompletionResponse.TokenUsage result = VertexConverter.convertUsage(metadata);
+		CompletionResponse.TokenUsage result = VertexConverter.convertUsage(metadata, null);
 
 		assertNotNull(result);
 		assertEquals(40, result.getCache_read_tokens());
@@ -201,7 +201,7 @@ class VertexConverterTest {
 				.totalTokenCount(170)
 				.build();
 
-		CompletionResponse.TokenUsage result = VertexConverter.convertUsage(metadata);
+		CompletionResponse.TokenUsage result = VertexConverter.convertUsage(metadata, null);
 
 		assertNotNull(result);
 		assertEquals(100, result.getPrompt_tokens());
@@ -226,7 +226,7 @@ class VertexConverterTest {
 				.candidatesTokensDetails(candidatesDetails)
 				.build();
 
-		CompletionResponse.TokenUsage result = VertexConverter.convertUsage(metadata);
+		CompletionResponse.TokenUsage result = VertexConverter.convertUsage(metadata, null);
 
 		assertNotNull(result);
 		assertNotNull(result.getCompletion_tokens_details());
@@ -251,7 +251,7 @@ class VertexConverterTest {
 				.candidatesTokensDetails(candidatesDetails)
 				.build();
 
-		CompletionResponse.TokenUsage result = VertexConverter.convertUsage(metadata);
+		CompletionResponse.TokenUsage result = VertexConverter.convertUsage(metadata, null);
 
 		assertNotNull(result);
 		assertNotNull(result.getCompletion_tokens_details());
@@ -281,7 +281,7 @@ class VertexConverterTest {
 				.candidatesTokensDetails(candidatesDetails)
 				.build();
 
-		CompletionResponse.TokenUsage result = VertexConverter.convertUsage(metadata);
+		CompletionResponse.TokenUsage result = VertexConverter.convertUsage(metadata, null);
 
 		assertNotNull(result);
 		assertEquals(80, result.getCompletion_tokens());
@@ -307,7 +307,7 @@ class VertexConverterTest {
 				.cacheTokensDetails(cacheDetails)
 				.build();
 
-		CompletionResponse.TokenUsage result = VertexConverter.convertUsage(metadata);
+		CompletionResponse.TokenUsage result = VertexConverter.convertUsage(metadata, null);
 
 		assertNotNull(result);
 		assertNotNull(result.getPrompt_tokens_details());
@@ -330,7 +330,7 @@ class VertexConverterTest {
 				.cacheTokensDetails(cacheDetails)
 				.build();
 
-		CompletionResponse.TokenUsage result = VertexConverter.convertUsage(metadata);
+		CompletionResponse.TokenUsage result = VertexConverter.convertUsage(metadata, null);
 
 		assertNotNull(result);
 		assertNotNull(result.getPrompt_tokens_details());
@@ -353,7 +353,7 @@ class VertexConverterTest {
 				.cacheTokensDetails(cacheDetails)
 				.build();
 
-		CompletionResponse.TokenUsage result = VertexConverter.convertUsage(metadata);
+		CompletionResponse.TokenUsage result = VertexConverter.convertUsage(metadata, null);
 
 		assertNotNull(result);
 		assertNull(result.getPrompt_tokens_details());
@@ -401,7 +401,7 @@ class VertexConverterTest {
 				.cacheTokensDetails(cacheDetails)
 				.build();
 
-		CompletionResponse.TokenUsage result = VertexConverter.convertUsage(metadata);
+		CompletionResponse.TokenUsage result = VertexConverter.convertUsage(metadata, null);
 
 		assertNotNull(result);
 		assertEquals(300, result.getPrompt_tokens());
@@ -429,7 +429,7 @@ class VertexConverterTest {
 				.promptTokensDetails(new ArrayList<>())
 				.build();
 
-		CompletionResponse.TokenUsage result = VertexConverter.convertUsage(metadata);
+		CompletionResponse.TokenUsage result = VertexConverter.convertUsage(metadata, null);
 
 		assertNotNull(result);
 		assertNotNull(result.getPrompt_tokens_details());
@@ -453,7 +453,7 @@ class VertexConverterTest {
 				.promptTokensDetails(promptDetails)
 				.build();
 
-		CompletionResponse.TokenUsage result = VertexConverter.convertUsage(metadata);
+		CompletionResponse.TokenUsage result = VertexConverter.convertUsage(metadata, null);
 
 		assertNotNull(result);
 		assertNotNull(result.getPrompt_tokens_details());
@@ -477,7 +477,7 @@ class VertexConverterTest {
 				.candidatesTokensDetails(candidatesDetails)
 				.build();
 
-		CompletionResponse.TokenUsage result = VertexConverter.convertUsage(metadata);
+		CompletionResponse.TokenUsage result = VertexConverter.convertUsage(metadata, null);
 
 		assertNotNull(result);
 		assertNull(result.getCompletion_tokens_details());
@@ -491,7 +491,7 @@ class VertexConverterTest {
 				.totalTokenCount(null)
 				.build();
 
-		CompletionResponse.TokenUsage result = VertexConverter.convertUsage(metadata);
+		CompletionResponse.TokenUsage result = VertexConverter.convertUsage(metadata, null);
 
 		assertNotNull(result);
 		assertEquals(0, result.getPrompt_tokens());


### PR DESCRIPTION
## 变更概述

为 Gemini/Vertex AI 适配层添加 Google Search grounding 工具支持，使用户可以通过 OpenAI 兼容接口调用 Gemini 的网络搜索能力，并实现搜索工具的费用计算。

## 变更详情

| 文件 | 改动类型 | 说明 |
|------|----------|------|
| `sdk/.../completion/Message.java` | 修改 | `Tool` 内部类添加 `@JsonAnySetter/@JsonAnyGetter` 支持任意工具类型（如 `google_search`） |
| `sdk/.../completion/CompletionResponse.java` | 修改 | `Choice` 添加 `grounding_metadata`，`TokenUsage` 添加 `tool_usage` |
| `sdk/.../completion/StreamCompletionResponse.java` | 修改 | `Choice` 添加 `grounding_metadata` |
| `sdk/.../completion/CompletionPriceInfo.java` | 修改 | 添加 `toolPrices` 字段支持工具计费 |
| `server/.../completion/VertexConverter.java` | 修改 | `convertTools()` 识别 `google_search` 工具；`convertUsage()` 提取搜索次数到 `tool_usage` |
| `server/.../gemini/GroundingMetadata.java` | 新增 | Gemini grounding 响应元数据 DTO |
| `server/.../gemini/Tool.java` | 修改 | 添加 `google_search` 字段 |
| `server/.../gemini/Candidate.java` | 修改 | 添加 `groundingMetadata` 字段 |
| `server/.../gemini/GeminiRequest.java` | 修改 | 添加 `toolConfig` 字段 |
| `server/.../gemini/VertexAdaptor.java` | 修改 | 流式场景追踪 `lastGroundingMetadata`，填充 `grounding_metadata` 和 `tool_usage` |
| `server/.../cost/CostCalculator.java` | 修改 | 添加 `calculateToolCost()` 静态方法，completion 和 responses 计费均支持工具费用 |
| `server/.../callback/MergeReasoningCallback.java` | 修改 | 适配 `Choice` 新增字段的构造函数 |
| `server/...test/.../VertexConverterTest.java` | 修改 | 适配 `convertUsage` 签名变更 |

## 关联 Issue
Closes LianjiaTech/bella-openapi#629

## 测试验证
- [ ] 发送带 `{"type": "function", "google_search": {}}` tools 的请求，验证 grounding 结果返回
- [ ] 验证响应中 `grounding_metadata` 包含搜索来源信息
- [ ] 验证 `usage.tool_usage.web_search` 正确计数
- [ ] 验证配置 `toolPrices` 后费用计算正确
- [ ] 验证不带 `google_search` 的普通请求不受影响

## 风险说明
无特殊风险，改动向后兼容

## 部署注意
如需启用搜索工具计费，需在模型 `priceInfo` 中配置 `toolPrices`，例如：`{"toolPrices": {"web_search": 0.035}}`