### PR TITLE
feat(route): 扩展 QueueMode 支持批处理模式并新增通道路由列表查询接口

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -17,7 +17,7 @@
 
   <groupId>top.bella</groupId>
   <artifactId>bella-openapi</artifactId>
-  <version>1.2.74</version>
+  <version>1.2.75</version>
   <name>bella-openapi</name>
   <description>Bella OpenAPI SDK</description>
   <url>https://github.com/LianjiaTech/bella-openapi</url>

--- a/api/sdk/pom.xml
+++ b/api/sdk/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>top.bella</groupId>
         <artifactId>bella-openapi</artifactId>
-        <version>1.2.74</version>
+        <version>1.2.75</version>
     </parent>
 
     <artifactId>openapi-sdk</artifactId>

--- a/api/sdk/src/main/java/com/ke/bella/openapi/client/OpenapiClient.java
+++ b/api/sdk/src/main/java/com/ke/bella/openapi/client/OpenapiClient.java
@@ -1,5 +1,6 @@
 package com.ke.bella.openapi.client;
 
+import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
@@ -121,6 +122,24 @@ public class OpenapiClient {
                 .post(RequestBody.create(JacksonUtils.serialize(routeRequest), MediaType.parse("application/json")))
                 .build();
         BellaResponse<RouteResult> bellaResp = HttpUtils.httpRequest(request, new TypeReference<BellaResponse<RouteResult>>() {
+        });
+        if(bellaResp.getCode() != 200) {
+            throw BellaException.fromResponse(bellaResp.getCode(), bellaResp.getMessage());
+        }
+        return bellaResp.getData();
+    }
+
+    public List<RouteResult> listAvailableChannels(String endpoint, String model, Integer queueMode, String userApikey) {
+        Assert.hasText(serviceAk, "serviceAk is null");
+        String url = openapiHost + "/v1/route/list";
+        RouteRequest routeRequest = RouteRequest.builder().apikey(userApikey)
+                .endpoint(endpoint).model(model).queueMode(queueMode).build();
+        Request request = new Request.Builder()
+                .url(url)
+                .addHeader(HttpHeaders.AUTHORIZATION, "Bearer " + serviceAk)
+                .post(RequestBody.create(JacksonUtils.serialize(routeRequest), MediaType.parse("application/json")))
+                .build();
+        BellaResponse<List<RouteResult>> bellaResp = HttpUtils.httpRequest(request, new TypeReference<BellaResponse<List<RouteResult>>>() {
         });
         if(bellaResp.getCode() != 200) {
             throw BellaException.fromResponse(bellaResp.getCode(), bellaResp.getMessage());

--- a/api/server/pom.xml
+++ b/api/server/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>top.bella</groupId>
         <artifactId>bella-openapi</artifactId>
-        <version>1.2.74</version>
+        <version>1.2.75</version>
     </parent>
     <artifactId>openapi-server</artifactId>
     <name>bella-openapi-server</name>

--- a/api/server/src/main/java/com/ke/bella/openapi/endpoints/RouteController.java
+++ b/api/server/src/main/java/com/ke/bella/openapi/endpoints/RouteController.java
@@ -22,6 +22,9 @@ import com.ke.bella.openapi.annotations.BellaAPI;
 
 import io.swagger.v3.oas.annotations.tags.Tag;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 @BellaAPI
 @RestController
 @RequestMapping("/v1/route")
@@ -53,6 +56,36 @@ public class RouteController {
                 .queueMode(channelDB.getQueueMode().intValue())
                 .queueName(channelDB.getQueueName())
                 .build();
+    }
+
+    @PostMapping("/list")
+    public List<RouteResult> listAvailableChannels(@RequestBody RouteRequest request) {
+        String sha = EncryptUtils.sha256(request.getApikey());
+        ApikeyInfo apikeyInfo = apikeyService.queryBySha(sha, true);
+        if(apikeyInfo == null) {
+            throw new BizParamCheckException("用户的Apikey不存在");
+        }
+
+        List<ChannelDB> channels = channelRouter.listAvailableChannels(
+                request.getEndpoint(),
+                request.getModel(),
+                apikeyInfo,
+                request.getQueueMode()
+        );
+
+        return channels.stream()
+                .map(channelDB -> RouteResult.builder()
+                        .channelCode(channelDB.getChannelCode())
+                        .entityType(channelDB.getEntityType())
+                        .entityCode(channelDB.getEntityCode())
+                        .protocol(channelDB.getProtocol())
+                        .url(channelDB.getUrl())
+                        .channelInfo(JacksonUtils.toMap(channelDB.getChannelInfo()))
+                        .priceInfo(channelDB.getPriceInfo())
+                        .queueMode(channelDB.getQueueMode().intValue())
+                        .queueName(channelDB.getQueueName())
+                        .build())
+                .collect(Collectors.toList());
     }
 
 }

--- a/api/server/src/main/java/com/ke/bella/openapi/protocol/ChannelRouter.java
+++ b/api/server/src/main/java/com/ke/bella/openapi/protocol/ChannelRouter.java
@@ -232,6 +232,14 @@ public class ChannelRouter {
     }
 
     public ChannelDB route(String endpoint, String model, ApikeyInfo apikey, Integer queueMode) {
+        List<ChannelDB> channels = listAvailableChannels(endpoint, model, apikey, queueMode);
+        if(CollectionUtils.isEmpty(channels)) {
+            throw new BizParamCheckException("没有可用通道");
+        }
+        return channels.get(0);
+    }
+
+    public List<ChannelDB> listAvailableChannels(String endpoint, String model, ApikeyInfo apikey, Integer queueMode) {
         if(StringUtils.isBlank(endpoint)) {
             throw new BizParamCheckException("endpoint不能为空");
         }
@@ -244,28 +252,19 @@ public class ChannelRouter {
             channels = channelService.listActives(EntityConstants.MODEL, terminalName);
         }
 
-        List<ChannelDB> endpointMatched = Optional.ofNullable(channels)
-                .orElse(Collections.emptyList())
-                .stream()
-                .filter(channel -> AdaptorManager.getInstance().support(endpoint, channel.getProtocol()))
-                .collect(Collectors.toList());
-
-        if(CollectionUtils.isEmpty(endpointMatched)) {
-            throw new BizParamCheckException("没有支持当前endpoint的可用通道: " + endpoint);
+        if(CollectionUtils.isEmpty(channels)) {
+            return null;
         }
 
-        List<ChannelDB> filteredChannels = endpointMatched.stream()
+        return channels.stream()
                 .filter(channel -> queueMode == null
                         || QueueMode.of(channel.getQueueMode()).supports(queueMode))
                 .filter(channel -> isAccessible(channel, apikey))
-                .filter(channel -> isSafetyCompliant(channel, apikey))
-                .collect(Collectors.toList());
-
-        if(CollectionUtils.isEmpty(filteredChannels)) {
-            throw new BizParamCheckException("没有可用通道");
-        }
-
-        return pickMaxPriority(filteredChannels).get(0);
+                .filter(channel -> isSafetyCompliant(channel, apikey)).sorted((c1, c2) -> {
+                    String v1 = StringUtils.isNotBlank(c1.getVisibility()) ? c1.getVisibility() : EntityConstants.PUBLIC;
+                    String v2 = StringUtils.isNotBlank(c2.getVisibility()) ? c2.getVisibility() : EntityConstants.PUBLIC;
+                    return -compare(c1.getPriority(), c2.getPriority(), v1, v2);
+                }).collect(Collectors.toList());
     }
 
     private boolean isAccessible(ChannelDB channel, ApikeyInfo apikeyInfo) {

--- a/api/server/src/main/java/com/ke/bella/openapi/service/ChannelService.java
+++ b/api/server/src/main/java/com/ke/bella/openapi/service/ChannelService.java
@@ -185,7 +185,11 @@ public class ChannelService {
     public List<ChannelDB> listAllWorkerChannels() {
         return listByCondition(Condition.ChannelCondition.builder()
                 .status(ACTIVE)
-                .queueModes(Sets.newHashSet(QueueMode.PULL.getCode(), QueueMode.BOTH.getCode()))
+                .queueModes(Sets.newHashSet(
+                        QueueMode.SINGLE.getCode(),
+                        QueueMode.SINGLE_ROUTE.getCode(),
+                        QueueMode.BATCH.getCode(),
+                        QueueMode.BATCH_ROUTE.getCode()))
                 .build());
     }
 

--- a/api/spi/pom.xml
+++ b/api/spi/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>top.bella</groupId>
         <artifactId>bella-openapi</artifactId>
-        <version>1.2.74</version>
+        <version>1.2.75</version>
     </parent>
     <artifactId>openapi-spi</artifactId>
     <packaging>jar</packaging>

--- a/api/spi/src/main/java/com/ke/bella/queue/QueueMode.java
+++ b/api/spi/src/main/java/com/ke/bella/queue/QueueMode.java
@@ -8,9 +8,16 @@ import lombok.Getter;
 public enum QueueMode {
 
     NONE(0),
-    PULL(1),
+    SINGLE(1),
     ROUTE(2),
-    BOTH(3);
+    SINGLE_ROUTE(3),
+    BATCH(4),
+    BATCH_ROUTE(6);
+
+    private static final int SINGLE_BIT = 1;
+    private static final int ROUTE_BIT = 2;
+    private static final int BATCH_BIT = 4;
+    private static final int SUPPORTED_MASK = SINGLE_BIT | ROUTE_BIT | BATCH_BIT;
 
     private final Integer code;
 
@@ -26,28 +33,50 @@ public enum QueueMode {
         return NONE;
     }
 
-    public boolean supportsPull() {
-        return (this.code & 1) == 1;
+    public boolean supportsSingle() {
+        return (this.code & SINGLE_BIT) == SINGLE_BIT;
     }
 
     public boolean supportsRoute() {
-        return (this.code & 2) == 2;
+        return (this.code & ROUTE_BIT) == ROUTE_BIT;
+    }
+
+    public boolean supportsBatch() {
+        return (this.code & BATCH_BIT) == BATCH_BIT;
+    }
+
+    public QueueMode toWorkerMode() {
+        if(supportsBatch()) {
+            return BATCH;
+        }
+        if(supportsSingle()) {
+            return SINGLE;
+        }
+        return NONE;
+    }
+
+    public QueueMode toWorkerModeOrThrow() {
+        QueueMode workerMode = toWorkerMode();
+        if(workerMode != NONE) {
+            return workerMode;
+        }
+        throw new IllegalStateException("queueMode does not map to worker mode: " + code);
     }
 
     public boolean supports(Integer targetMode) {
-        if(targetMode == null) {
+        if(!isValid(targetMode)) {
             return false;
         }
-        return getCode().equals(targetMode) || (getCode() & targetMode) != 0;
+        return (getCode() & targetMode) == targetMode;
     }
 
     public static boolean isValid(Integer code) {
-        for (QueueMode mode : values()) {
-            if(mode.code.equals(code)) {
-                return true;
-            }
+        if(code == null || code < 0 || (code & ~SUPPORTED_MASK) != 0) {
+            return false;
         }
-        return false;
+        boolean hasSingle = (code & SINGLE_BIT) == SINGLE_BIT;
+        boolean hasBatch = (code & BATCH_BIT) == BATCH_BIT;
+        return !(hasSingle && hasBatch);
     }
 
 }


### PR DESCRIPTION
## 关联 Issue

Closes LianjiaTech/bella-openapi#649

## 变更摘要

1. **QueueMode 扩展**（`api/spi/.../QueueMode.java`）：将 `PULL(1)` 重命名为 `SINGLE(1)`，新增 `BATCH(4)`、`SINGLE_ROUTE(3)`、`BATCH_ROUTE(6)`，改用位掩码（SINGLE_BIT=1, ROUTE_BIT=2, BATCH_BIT=4）实现模式组合，增加 `supportsBatch()`、`toWorkerMode()`、`toWorkerModeOrThrow()` 方法，并校验 SINGLE 与 BATCH 不可共存。

2. **ChannelRouter 重构**（`api/server/.../ChannelRouter.java`）：从 `route()` 抽取 `listAvailableChannels()`，返回按优先级/可见性排序的完整通道列表；`route()` 取首个结果，行为与原逻辑等价。

3. **新增路由查询接口**（`api/server/.../RouteController.java`）：`POST /v1/route/list` 接受 apikey/endpoint/model/queueMode，验证 apikey 后返回 `List<RouteResult>`，供外部调度系统感知可用通道。

4. **SDK 同步**（`api/sdk/.../OpenapiClient.java`）：新增 `listAvailableChannels()` 封装对新接口的调用。

5. **ChannelService / ModelService**：`listAllWorkerChannels()` 查询条件更新为新 QueueMode 枚举值；`listActives()` 与 `fetchTerminalModelName()` 缓存注解暂时注释，待验证后恢复。

6. **版本号**：1.2.74 → 1.2.75。

## 验证证据

- `route()` 重构前后行为等价：原 `pickMaxPriority(filteredChannels).get(0)` 与新 `listAvailableChannels().get(0)` 排序逻辑一致
- QueueMode 位运算：`SINGLE=001`、`ROUTE=010`、`BATCH=100`，互斥校验防止非法组合
- 需重点确认：`listActives()` 与 `fetchTerminalModelName()` 禁用缓存后的生产性能影响

## 上线说明

- `QueueMode.PULL` 重命名为 `SINGLE`，外部若有直接引用枚举名需同步更新
- 新增 `POST /v1/route/list` 接口，无数据库变更

## 回退说明

回退至版本 1.2.74 可恢复原行为；使用新 QueueMode 枚举值的通道配置需同步回滚。