### PR TITLE
fix(QueueAdaptor): 切换至默认渠道时重置 supplier 和 forwardUrl

### DIFF
--- a/api/server/src/main/java/com/ke/bella/openapi/protocol/completion/QueueAdaptor.java
+++ b/api/server/src/main/java/com/ke/bella/openapi/protocol/completion/QueueAdaptor.java
@@ -85,6 +85,8 @@ public class QueueAdaptor<T extends CompletionProperty> implements CompletionAda
         }
         if(DEFAULT_CHANNEL.equals(returnedChannelCode)) {
             processData.setChannelCode(DEFAULT_CHANNEL);
+            processData.setSupplier("ke");
+            processData.setForwardUrl(StringUtils.EMPTY);
             return;
         }
         ChannelDB channel = channelLookup.apply(returnedChannelCode);


### PR DESCRIPTION
## 关联 Issue

Closes LianjiaTech/bella-openapi#661

## 变更摘要

`QueueAdaptor.updateChannelInfo` 在判断返回渠道码为 `DEFAULT_CHANNEL` 时，
原代码仅设置 `channelCode`，未重置 `supplier` 和 `forwardUrl`，
导致原渠道信息残留，影响费用归因和转发地址记录的准确性。

本次修复在该分支补充：
- `processData.setSupplier("ke")` — 将供应商重置为内部默认值
- `processData.setForwardUrl(StringUtils.EMPTY)` — 清空转发地址

## 验证证据

- 改动范围极小（2 行），逻辑与同方法内其他渠道的赋值路径对称
- 需重点确认：`DEFAULT_CHANNEL` 场景下下游费用核算逻辑是否依赖 `supplier` 字段

## 上线说明

N/A

## 回退说明

N/A